### PR TITLE
feature/add-organisation-id

### DIFF
--- a/pkg/models/media.go
+++ b/pkg/models/media.go
@@ -14,6 +14,7 @@ type Media struct {
 	DeviceId string `json:"deviceId,omitempty" bson:"deviceId,omitempty"`
 	GroupId  string `json:"groupId,omitempty" bson:"groupId,omitempty"`
 	UserId   string `json:"userId,omitempty" bson:"userId,omitempty"`
+	OrganisationId string `json:"organisationId,omitempty" bson:"organisationId,omitempty"`
 
 	// Media file information (by default Vault (=kstorage), however might change
 	// in the future (integration with other storage solutions, next to Vault).


### PR DESCRIPTION
## Description

### Pull Request Description

**Title:** feature/add-organisation-id

**Motivation:**
The primary motivation behind this change is to enhance the data model by including the `OrganisationId` field within the `Media` struct. This addition improves the granularity and relevance of the data stored, enabling better data segmentation and more precise queries. By associating media records with specific organizations, we can improve data management, access control, and reporting capabilities.

**Changes:**
- Added `OrganisationId` field to the `Media` struct in `pkg/models/media.go`:
  ```go
  type Media struct {
      DeviceId        string `json:"deviceId,omitempty" bson:"deviceId,omitempty"`
      GroupId         string `json:"groupId,omitempty" bson:"groupId,omitempty"`
      UserId          string `json:"userId,omitempty" bson:"userId,omitempty"`
      OrganisationId  string `json:"organisationId,omitempty" bson:"organisationId,omitempty"`
      // Media file information (by default Vault (=kstorage), however might change
      // in the future (integration with other storage solutions, next to Vault).
  }
  ```

**Benefits:**
1. **Improved Data Segmentation:** Allows for better grouping and filtering of media records by organization.
2. **Enhanced Access Control:** Facilitates more precise access controls based on organizational boundaries.
3. **Better Reporting:** Enables more detailed and organization-specific reporting and analytics.

This change is a crucial step towards enhancing our data model to support more complex and organization-specific use cases, ensuring our system can scale and meet the diverse needs of different organizational entities.