### PR TITLE
feature/add-heartbeat-signals

### DIFF
--- a/pkg/api/application.go
+++ b/pkg/api/application.go
@@ -5,6 +5,12 @@ type ApplicationStatus string
 
 const (
 	PongSuccess ApplicationStatus = "pong_success"
+	DatabaseSuccess ApplicationStatus = "database_success"
+	DatabaseError ApplicationStatus = "database_error"
+	QueueSuccess ApplicationStatus = "queue_success"
+	QueueError ApplicationStatus = "queue_error"
+	CacheSuccess ApplicationStatus = "cache_success"
+	CacheError ApplicationStatus = "cache_error"
 )
 
 // String returns the string representation of the application status


### PR DESCRIPTION
## Description

### Pull Request Description

**Title: feature/add-heartbeat-signals**

#### Motivation and Improvement

This pull request introduces enhanced heartbeat signals to our application status monitoring system. The primary motivation behind these changes is to improve the observability and reliability of our system by providing more granular and precise status updates for critical components such as the database, queue, and cache.

#### Changes Made

- **Added new ApplicationStatus constants:**
  - `DatabaseSuccess`
  - `DatabaseError`
  - `QueueSuccess`
  - `QueueError`
  - `CacheSuccess`
  - `CacheError`

These new status constants will allow the application to report the success or failure of operations related to the database, queue, and cache systems explicitly. Previously, our status monitoring was limited to a generic "pong" success signal, which did not provide detailed insights into the state of these critical components.

#### Why It Improves the Project

1. **Enhanced Monitoring:**
   - By adding specific success and error signals for the database, queue, and cache, we can now monitor the health and performance of these components more effectively.
   - This granularity allows for quicker identification and resolution of issues, reducing downtime and improving overall system reliability.

2. **Improved Debugging:**
   - With distinct error signals, developers can pinpoint the source of a problem more rapidly, facilitating faster debugging and troubleshooting processes.
   - This leads to reduced mean time to resolution (MTTR) for incidents.

3. **Better Reporting:**
   - Detailed status reporting supports better logging and alerting mechanisms, enabling more proactive system maintenance and issue prevention.
   - This improvement aligns with best practices for observability and system health monitoring.

In summary, this change significantly enhances our ability to monitor, debug, and maintain the health of our application, leading to improved reliability and performance.