### PR TITLE
chore: remove project context section from Copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,11 +1,3 @@
-# GitHub Copilot Instructions for UUG AI Models Repository
-
-## Project Context
-This is a Go package that defines data models for media file management and metadata handling in the UUG AI ecosystem. The repository includes:
-- Go model definitions in `pkg/models/`
-- API response structures in `pkg/api/`
-- Automatic TypeScript type generation from Go models
-- Support for MongoDB (BSON) and REST APIs (JSON)
 
 ## Commit Message Format
 


### PR DESCRIPTION
## Description

### Pull Request Description

**Title:** chore: remove project context section from Copilot instructions

**Motivation:**
The project context section in the GitHub Copilot instructions is redundant and does not add significant value to the instructions. Users utilizing Copilot are primarily interested in the specific guidelines for commit messages and other coding standards rather than the broader project context. Removing this section streamlines the document, making it more concise and focused.

**Changes:**
- Removed the "Project Context" section from `.github/copilot-instructions.md`.

**Why it improves the project:**
By eliminating unnecessary information, the instructions become clearer and more straightforward, enhancing the user experience for developers. This change ensures that the document focuses solely on the actionable guidelines, thus improving readability and usability.