### PR TITLE
bug/rename-metaData

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -52,7 +52,9 @@ type Metadata struct {
 	Error          string         `json:"error,omitempty" bson:"error,omitempty"`                   // Error message if any
 	MissingFields  []string       `json:"missingFields,omitempty" bson:"missingFields,omitempty"`   // List of missing fields in the request
 	Language       string         `json:"language,omitempty" bson:"language,omitempty"`             // Language of the response, if applicable
-	Data           map[string]any `json:"data,omitempty" bson:"data,omitempty"`                     // Additional data relevant to the request or response, this can be free-format
+	Data           map[string]any `json:"data,omitempty" bson:"data,omitempty"`
+	// Additional data relevant to the request or response, this can be free-format
+	Pagination *CursorPagination `json:"pagination,omitempty" bson:"pagination,omitempty"`
 }
 
 // SuccessResponse represents a standard success response structure.
@@ -61,7 +63,7 @@ type SuccessResponse struct {
 	ApplicationStatusCode string   `json:"applicationStatusCode,omitempty" bson:"applicationStatusCode,omitempty"` // Application-specific status code
 	EntityStatusCode      string   `json:"entityStatusCode,omitempty" bson:"entityStatusCode,omitempty"`           // Entity-specific status code
 	Message               string   `json:"message,omitempty" bson:"message,omitempty"`                             // Success message describing the operation
-	MetaData              Metadata `json:"metaData,omitempty" bson:"metaData,omitempty"`                           // Additional metadata about the response, such as timestamps and request IDs
+	Metadata              Metadata `json:"metadata,omitempty" bson:"metadata,omitempty"`                           // Additional metadata about the response, such as timestamps and request IDs
 }
 
 func CreateSuccess(httpStatusCode int, applicationStatusCode string, entityStatusCode EntityStatus, metadata Metadata) SuccessResponse {
@@ -71,7 +73,7 @@ func CreateSuccess(httpStatusCode int, applicationStatusCode string, entityStatu
 		ApplicationStatusCode: applicationStatusCode,
 		EntityStatusCode:      entityStatusCode.String(),
 		Message:               entityStatusCode.Translate(metadata.Language),
-		MetaData:              metadata,
+		Metadata:              metadata,
 	}
 }
 
@@ -81,7 +83,7 @@ type ErrorResponse struct {
 	ApplicationStatusCode string   `json:"applicationStatusCode,omitempty" bson:"applicationStatusCode,omitempty"` // Application-specific error code
 	EntityStatusCode      string   `json:"entityStatusCode,omitempty" bson:"entityStatusCode,omitempty"`           // Entity-specific error code
 	Message               string   `json:"message,omitempty" bson:"message,omitempty"`                             // Error message describing the issue
-	MetaData              Metadata `json:"metaData,omitempty" bson:"metaData,omitempty"`                           // Additional metadata about the error, such as timestamps and request IDs
+	Metadata              Metadata `json:"metadata,omitempty" bson:"metadata,omitempty"`                           // Additional metadata about the error, such as timestamps and request IDs
 }
 
 func CreateError(httpStatusCode int, applicationStatusCode string, entityStatusCode EntityStatus, metadata Metadata) ErrorResponse {
@@ -91,7 +93,7 @@ func CreateError(httpStatusCode int, applicationStatusCode string, entityStatusC
 		ApplicationStatusCode: applicationStatusCode,
 		EntityStatusCode:      entityStatusCode.String(),
 		Message:               entityStatusCode.Translate(metadata.Language),
-		MetaData:              metadata,
+		Metadata:              metadata,
 	}
 }
 
@@ -103,7 +105,7 @@ func LogInfo(logger *logrus.Logger, entityStatusCode EntityStatus, metadata Meta
 		"applicationStatusCode": ApplicationStatusSuccess,
 		"entityStatusCode":      entityStatusCode.String(),
 		"message":               entityStatusCode.Translate(metadata.Language),
-		"metaData":              metadata,
+		"metadata":              metadata,
 	}).Info()
 }
 
@@ -114,7 +116,7 @@ func LogError(logger *logrus.Logger, entityStatusCode EntityStatus, metadata Met
 		"applicationStatusCode": ApplicationStatusError,
 		"entityStatusCode":      entityStatusCode.String(),
 		"message":               entityStatusCode.Translate(metadata.Language),
-		"metaData":              metadata,
+		"metadata":              metadata,
 	}).Error()
 }
 
@@ -125,6 +127,6 @@ func LogDebug(logger *logrus.Logger, entityStatusCode EntityStatus, metadata Met
 		"applicationStatusCode": ApplicationStatusSuccess,
 		"entityStatusCode":      entityStatusCode.String(),
 		"message":               entityStatusCode.Translate(metadata.Language),
-		"metaData":              metadata,
+		"metadata":              metadata,
 	}).Debug()
 }

--- a/pkg/models/marker.go
+++ b/pkg/models/marker.go
@@ -27,7 +27,7 @@ type Marker struct {
 	Description string        `json:"description,omitempty" bson:"description,omitempty" example:"Person forcably opened a door"` // Description of the marker
 
 	// Additional metadata
-	MetaData *MarkerMetadata `json:"metaData,omitempty" bson:"metaData,omitempty"` // Metadata associated with the marker, such as comments and tags
+	Metadata *MarkerMetadata `json:"metadata,omitempty" bson:"metadata,omitempty"` // Metadata associated with the marker, such as comments and tags
 
 	// Synchronize
 	Synchronize *Synchronize `json:"synchronize,omitempty" bson:"synchronize,omitempty"` // Synchronization status with external systems

--- a/pkg/models/pipeline.go
+++ b/pkg/models/pipeline.go
@@ -64,7 +64,7 @@ type PipelinePayload struct {
 	BytesRangeOnTime []FragmentedBytesRangeOnTime `json:"bytes_range_on_time" bson:"bytes_range_on_time"`
 
 	// Metadata
-	MetaData PipelineMetadata `json:"metadata,omitempty"`
+	Metadata PipelineMetadata `json:"metadata,omitempty"`
 }
 
 type PipelineMetadata struct {


### PR DESCRIPTION
## Description

### Pull Request: `bug/rename-metaData`

#### Motivation and Improvement

The primary motivation behind this pull request is to standardize the naming convention for metadata fields across the project. Previously, the project used a mix of `MetaData` and `Metadata`, leading to inconsistencies in the codebase. This inconsistency could cause confusion among developers and increase the likelihood of bugs.

By renaming all instances of `MetaData` to `Metadata`, we achieve the following improvements:

1. **Consistency**: Ensures a uniform naming convention throughout the codebase, making it easier to understand and maintain.
2. **Readability**: Improves code readability by using a commonly accepted naming standard.
3. **Error Reduction**: Reduces the potential for errors related to inconsistent naming.

#### Summary of Changes

- Renamed `MetaData` to `Metadata` in various structs and function signatures across multiple files.
- Updated JSON and BSON tags to reflect the new naming convention.
- Added a new `Pagination` field to the `Metadata` struct in `pkg/api/api.go` to handle cursor-based pagination.

#### Files Affected

- **pkg/api/api.go**: 
  - Renamed `MetaData` to `Metadata`.
  - Added `Pagination` field to `Metadata` struct.
- **pkg/models/marker.go**:
  - Renamed `MetaData` to `Metadata` in the `Marker` struct.
- **pkg/models/pipeline.go**:
  - Renamed `MetaData` to `Metadata` in the `PipelinePayload` struct.

By implementing these changes, we align the codebase with best practices, improving overall code quality and maintainability.