### PR TITLE
feature/add-device-name-to-media

### DIFF
--- a/pkg/models/media.go
+++ b/pkg/models/media.go
@@ -64,6 +64,8 @@ type MediaMetadata struct {
 	DominantColors  []string `json:"dominantColors,omitempty" bson:"dominantColors,omitempty"`
 	Count           int      `json:"count,omitempty" bson:"count,omitempty"`
 	Embedding       []int    `json:"embedding,omitempty" bson:"embedding,omitempty"`
+
+	DeviceName string `json:"deviceName,omitempty" bson:"deviceName,omitempty"`
 }
 
 // MediaAtRuntimeMetadata contains metadata that is generated at runtime, which can include


### PR DESCRIPTION
## Description

## Pull Request Description

### Title: feature/add-device-name-to-media

### Motivation and Context
The primary motivation behind this change is to enhance the metadata associated with media files by including the device name used to capture or create the media. This additional piece of information can be crucial for various use cases, such as media management, organization, and analytics. By knowing the device name, users and systems can better understand the origin of the media, which can be useful for troubleshooting, categorization, and providing more context to the media files.

### Changes Made
- Added a new field `DeviceName` to the `MediaMetadata` struct in `pkg/models/media.go`.
  ```go
  type MediaMetadata struct {
      DominantColors  []string `json:"dominantColors,omitempty" bson:"dominantColors,omitempty"`
      Count           int      `json:"count,omitempty" bson:"count,omitempty"`
      Embedding       []int    `json:"embedding,omitempty" bson:"embedding,omitempty"`
      DeviceName      string   `json:"deviceName,omitempty" bson:"deviceName,omitempty"`
  }
  ```

### Why It Improves the Project
1. **Enhanced Metadata**: Adding the device name enriches the metadata associated with each media file, providing more context and information.
2. **Improved Organization**: Users and systems can now organize and filter media files based on the device name, making media management more efficient.
3. **Better Analytics**: Understanding the distribution of devices used for capturing media can offer valuable insights for analytics and reporting.
4. **Troubleshooting**: Knowing the device name can aid in troubleshooting issues related to specific devices, leading to quicker resolutions.

By incorporating the device name into the media metadata, we are making the system more robust, informative, and user-friendly. This change aligns with our goal of continually improving the functionality and usability of our project.