### PR TITLE
fix/health-status-renaming

### DIFF
--- a/pkg/api/health.go
+++ b/pkg/api/health.go
@@ -6,14 +6,14 @@ import "github.com/uug-ai/models/pkg/models"
 type HealthStatus string
 
 const (
-	NotHealtyDatabase                   HealthStatus = "no_healthy_database"
-	NotHealthyQueue                     HealthStatus = "no_healthy_queue"
-	NotHealtyLicense                    HealthStatus = "no_valid_license"
-	NotHealthDatabaseAndQueue           HealthStatus = "no_healthy_database_and_queue"
-	NotHealthyLicenseAndQueue           HealthStatus = "no_valid_license_and_queue"
-	NotHealthyLicenseAndDatabase        HealthStatus = "no_valid_license_and_healthy_database"
-	NotHealthDatabaseAndLicenseAndQueue HealthStatus = "no_healthy_database_no_valid_license_and_queue"
-	Healthy                             HealthStatus = "healthy"
+	NotHealthyLicense                    HealthStatus = "not_healthy_license"
+	NotHealthyDatabase                   HealthStatus = "not_healthy_database"
+	NotHealthyQueue                      HealthStatus = "not_healthy_queue"
+	NotHealthyDatabaseAndQueue           HealthStatus = "not_healthy_database_and_queue"
+	NotHealthyLicenseAndQueue            HealthStatus = "not_healthy_license_and_queue"
+	NotHealthyLicenseAndDatabase         HealthStatus = "not_healthy_license_and_database"
+	NotHealthyDatabaseAndLicenseAndQueue HealthStatus = "not_healthy_database_and_license_and_queue"
+	Healthy                              HealthStatus = "healthy"
 )
 
 // String returns the string representation of the marker status
@@ -25,34 +25,34 @@ func (ms HealthStatus) String() string {
 func (ms HealthStatus) Translate(lang string) string {
 	translations := map[string]map[HealthStatus]string{
 		"en": {
-			NotHealtyDatabase:                   "Database is not healthy",
-			NotHealthyQueue:                     "Queue is not healthy",
-			NotHealtyLicense:                    "License is not valid",
-			NotHealthDatabaseAndQueue:           "Database and queue are not healthy",
-			NotHealthyLicenseAndQueue:           "License is not valid and queue is not healthy",
-			NotHealthyLicenseAndDatabase:        "License is not valid and database is not healthy",
-			NotHealthDatabaseAndLicenseAndQueue: "Database is not healthy, license is not valid, and queue is not healthy",
-			Healthy:                             "Healthy",
+			NotHealthyDatabase:                   "Database is not healthy",
+			NotHealthyQueue:                      "Queue is not healthy",
+			NotHealthyLicense:                    "License is not healthy",
+			NotHealthyDatabaseAndQueue:           "Database and queue are not healthy",
+			NotHealthyLicenseAndQueue:            "License is not healthy and queue is not healthy",
+			NotHealthyLicenseAndDatabase:         "License is not healthy and database is not healthy",
+			NotHealthyDatabaseAndLicenseAndQueue: "Database is not healthy, license is not healthy, and queue is not healthy",
+			Healthy:                              "Healthy",
 		},
 		"es": {
-			NotHealtyDatabase:                   "La base de datos no está saludable",
-			NotHealthyQueue:                     "La cola no está saludable",
-			NotHealtyLicense:                    "La licencia no es válida",
-			NotHealthDatabaseAndQueue:           "La base de datos y la cola no están saludables",
-			NotHealthyLicenseAndQueue:           "La licencia no es válida y la cola no está saludable",
-			NotHealthyLicenseAndDatabase:        "La licencia no es válida y la base de datos no está saludable",
-			NotHealthDatabaseAndLicenseAndQueue: "La base de datos no está saludable, la licencia no es válida y la cola no está saludable",
-			Healthy:                             "Saludable",
+			NotHealthyDatabase:                   "La base de datos no está saludable",
+			NotHealthyQueue:                      "La cola no está saludable",
+			NotHealthyLicense:                    "La licencia no está saludable",
+			NotHealthyDatabaseAndQueue:           "La base de datos y la cola no están saludables",
+			NotHealthyLicenseAndQueue:            "La licencia no está saludable y la cola no está saludable",
+			NotHealthyLicenseAndDatabase:         "La licencia no está saludable y la base de datos no está saludable",
+			NotHealthyDatabaseAndLicenseAndQueue: "La base de datos no está saludable, la licencia no está saludable y la cola no está saludable",
+			Healthy:                              "Saludable",
 		},
 		"fr": {
-			NotHealtyDatabase:                   "La base de données n'est pas saine",
-			NotHealthyQueue:                     "La file d'attente n'est pas saine",
-			NotHealtyLicense:                    "La licence n'est pas valide",
-			NotHealthDatabaseAndQueue:           "La base de données et la file d'attente ne sont pas saines",
-			NotHealthyLicenseAndQueue:           "La licence n'est pas valide et la file d'attente n'est pas saine",
-			NotHealthyLicenseAndDatabase:        "La licence n'est pas valide et la base de données n'est pas saine",
-			NotHealthDatabaseAndLicenseAndQueue: "La base de données n'est pas saine, la licence n'est pas valide et la file d'attente n'est pas saine",
-			Healthy:                             "Saine",
+			NotHealthyDatabase:                   "La base de données n'est pas saine",
+			NotHealthyQueue:                      "La file d'attente n'est pas saine",
+			NotHealthyLicense:                    "La licence n'est pas saine",
+			NotHealthyDatabaseAndQueue:           "La base de données et la file d'attente ne sont pas saines",
+			NotHealthyLicenseAndQueue:            "La licence n'est pas saine et la file d'attente n'est pas saine",
+			NotHealthyLicenseAndDatabase:         "La licence n'est pas saine et la base de données n'est pas saine",
+			NotHealthyDatabaseAndLicenseAndQueue: "La base de données n'est pas saine, la licence n'est pas saine et la file d'attente n'est pas saine",
+			Healthy:                              "Saine",
 		},
 	}
 


### PR DESCRIPTION
## Description

### Pull Request Description

#### Motivation
The purpose of this pull request is to correct and standardize the naming conventions of various health status constants in the `pkg/api/health.go` file. The previous naming had inconsistencies and typographical errors, such as "NotHealty" instead of "NotHealthy." These inconsistencies can lead to confusion and errors in the codebase, especially for new developers or contributors.

#### Improvements
1. **Consistency:** By renaming the constants to follow a consistent naming pattern (`not_healthy_*`), the code becomes more readable and maintainable.
2. **Clarity:** Correcting the spelling mistakes ensures that the names of the constants accurately reflect their purpose, reducing the likelihood of misunderstandings or misuse.
3. **Localization:** Updates to translations in multiple languages (English, Spanish, and French) to reflect the corrected constant names ensure that the health status messages are accurate and clear across different locales.

#### Summary of Changes
- Corrected the spelling of health status constants.
- Standardized the naming convention for all health status constants.
- Updated the corresponding translations in English, Spanish, and French.
- Ensured that all references to these constants in the codebase reflect the new names.

By making these changes, we improve the overall quality and maintainability of the code, making it easier for current and future developers to work with the health status constants.