### PR TITLE
fix/change-status-types

### DIFF
--- a/pkg/models/health.go
+++ b/pkg/models/health.go
@@ -1,12 +1,12 @@
 package models
 
-
 type Health struct {
 
+	// Health status fields
 	Description string `json:"description,omitempty" bson:"description,omitempty"`
-	Database	string `json:"database,omitempty" bson:"database,omitempty"`
-	Queue		string `json:"queue,omitempty" bson:"queue,omitempty"`
-	License		string `json:"license,omitempty" bson:"license,omitempty"`
+	Database    bool   `json:"database,omitempty" bson:"database,omitempty"`
+	Queue       bool   `json:"queue,omitempty" bson:"queue,omitempty"`
+	License     bool   `json:"license,omitempty" bson:"license,omitempty"`
 
 	// Additional metadata
 	Metadata *HealthMetadata `json:"metadata,omitempty" bson:"metadata,omitempty"` // Metadata associated with the health, such as comments and tags
@@ -28,5 +28,4 @@ type HealthMetadata struct {
 }
 
 type HealthAtRuntimeMetadata struct {
-	
 }


### PR DESCRIPTION
## Description

### Pull Request Description: Fix/Change-Status-Types

#### Motivation

The current implementation of the `Health` struct in the project uses string types for fields that represent boolean states. This can lead to ambiguity and potential errors in interpreting the health status of various components (e.g., database, queue, and license). By changing these fields to boolean types, we can more accurately represent the binary nature of these statuses and improve data integrity and clarity.

#### Changes

- Update `Health` struct in `pkg/models/health.go`:
  - Change the types of `Database`, `Queue`, and `License` fields from `string` to `bool`.
  - Ensure that the JSON and BSON tags remain consistent for serialization and deserialization.
  
#### Why It Improves the Project

1. **Data Integrity**: Using boolean types for fields that represent true/false states reduces the risk of invalid values (e.g., any string other than "true" or "false").
2. **Clarity and Readability**: Boolean fields clearly convey that the status can only be true or false, making the code easier to understand and maintain.
3. **Consistency**: Ensures that the health status is consistently represented and interpreted across different parts of the application.
4. **Performance**: Boolean fields consume less memory compared to strings and can lead to slight performance improvements, especially when dealing with large datasets.

By implementing these changes, we enhance the robustness and maintainability of our codebase, ensuring that health status checks are accurate and reliable.