### PR TITLE
feature/add-deadletter-queue-panic-statusses

### DIFF
--- a/pkg/api/pipeline.go
+++ b/pkg/api/pipeline.go
@@ -22,15 +22,18 @@ const (
 type PipelineStatus string
 
 const (
-	UserMissing         PipelineStatus = "user_missing"
-	TraceIdMissing      PipelineStatus = "trace_id_missing"
-	UserEmailEmpty      PipelineStatus = "user_email_empty"
-	MediaMissing        PipelineStatus = "media_missing"
-	IONotFound          PipelineStatus = "io_not_found"
-	IODecodeError       PipelineStatus = "io_decode_error"
-	SignedUrlFailed     PipelineStatus = "signed_url_failed"
-	ThumbnailMissing    PipelineStatus = "thumbnail_missing"
-	QueueCreationFailed PipelineStatus = "queue_creation_failed"
+	UserMissing                PipelineStatus = "user_missing"
+	TraceIdMissing             PipelineStatus = "trace_id_missing"
+	UserEmailEmpty             PipelineStatus = "user_email_empty"
+	MediaMissing               PipelineStatus = "media_missing"
+	IONotFound                 PipelineStatus = "io_not_found"
+	IODecodeError              PipelineStatus = "io_decode_error"
+	SignedUrlFailed            PipelineStatus = "signed_url_failed"
+	ThumbnailMissing           PipelineStatus = "thumbnail_missing"
+	QueueCreationFailed        PipelineStatus = "queue_creation_failed"
+	PanicRecovered             PipelineStatus = "panic_recovered"
+	DeadLetterQueueSendSuccess PipelineStatus = "dead_letter_queue_send_success"
+	DeadLetterQueueSendFailed  PipelineStatus = "dead_letter_queue_send_failed"
 )
 
 func (ps PipelineStatus) String() string {


### PR DESCRIPTION
## Description

### Pull Request Description: feature/add-deadletter-queue-panic-statusses

#### Motivation
The primary motivation behind this change is to enhance the robustness and reliability of our pipeline status tracking. By adding new statuses related to panic recovery and dead-letter queue operations, we can more accurately monitor and diagnose issues that occur during pipeline execution.

#### Improvements
1. **Enhanced Error Tracking**: The addition of `PanicRecovered` status allows us to explicitly capture and log instances where the pipeline recovers from a panic situation, enabling better debugging and issue resolution.
2. **Dead-Letter Queue Monitoring**: Introducing `DeadLetterQueueSendSuccess` and `DeadLetterQueueSendFailed` statuses provides visibility into the success or failure of sending messages to the dead-letter queue, which is critical for handling and troubleshooting message processing errors.
3. **Consistency and Clarity**: The reformatting of existing statuses ensures better readability and consistency, making the codebase easier to maintain and understand.

Overall, these changes contribute to a more resilient and transparent pipeline execution process, improving our ability to handle and resolve errors effectively.