### PR TITLE
feature/rename-pipelineactions

### DIFF
--- a/pkg/models/pipeline.go
+++ b/pkg/models/pipeline.go
@@ -100,13 +100,13 @@ type PipelineAction string
 
 const (
 	// Forward indicates the message should be forwarded to the next stage
-	Forward PipelineAction = "forward"
+	PipelineForward PipelineAction = "forward"
 	// Cancel indicates the message processing should be cancelled
-	Cancel PipelineAction = "cancel"
+	PipelineCancel PipelineAction = "cancel"
 	// Retry indicates the message should be retried
-	Retry PipelineAction = "retry"
+	PipelineRetry PipelineAction = "retry"
 	// Error indicates an error occurred during message processing
-	Error PipelineAction = "error"
+	PipelineError PipelineAction = "error"
 )
 
 // PipelineMetrics represents processing metrics for a pipeline event


### PR DESCRIPTION
## Description

### Pull Request Description

#### Title: feature/rename-pipelineactions

#### Motivation
The motivation behind this change is to improve code readability and consistency in naming conventions within the project. The original naming of pipeline actions such as `Forward`, `Cancel`, `Retry`, and `Error` were not immediately clear in their context. By prefixing them with `Pipeline`, we make it explicit that these actions pertain to pipeline processing, enhancing the clarity for developers who read and maintain the code.

#### Changes
- Renamed pipeline actions to include a `Pipeline` prefix for better context clarity:
  - `Forward` -> `PipelineForward`
  - `Cancel` -> `PipelineCancel`
  - `Retry` -> `PipelineRetry`
  - `Error` -> `PipelineError`

#### Why It Improves the Project
1. **Enhanced Readability**: The new naming convention makes it immediately clear that these constants are related to pipeline actions, reducing cognitive load and potential confusion.
2. **Consistency**: Prefixing action names with `Pipeline` aligns with consistent naming practices, making the codebase easier to navigate and understand.
3. **Maintainability**: Future developers will benefit from the improved clarity, making it easier to maintain and extend the pipeline functionality.

This change is a straightforward improvement that contributes to the overall quality and maintainability of the project.