### PR TITLE
feature/media-details

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,6 +387,10 @@ DEBUG=true npm run generate
 ### API Models (`pkg/api/`)
 
 - `ErrorResponse` - Standard error responses
+
+### Selective Fields
+
+Clients can request optional fields on certain API payloads using the `include` parameter in request models. For example, site option queries support `include: ["metadata"]` to return site metadata alongside the default fields.
 - `HealthResponse` - Health check responses
 - `PaginationResponse` - Paginated list responses
 - `MediaResponse` - Media query responses

--- a/pkg/api/site.go
+++ b/pkg/api/site.go
@@ -64,13 +64,19 @@ func (ds SiteStatus) Translate(lang string) string {
 }
 
 type SiteFilter struct {
-	SiteIds []*string `json:"siteIds,omitempty" bson:"siteIds,omitempty"`
-	Name    *string   `json:"name,omitempty" bson:"name,omitempty"`
+	SiteIds    []*string `json:"siteIds,omitempty" bson:"siteIds,omitempty"`
+	Name       *string   `json:"name,omitempty" bson:"name,omitempty"`
+	DeviceKeys []string  `json:"deviceKeys,omitempty" bson:"deviceKeys,omitempty"`
+}
+
+type SiteFlags struct {
+	IncludeMetadata bool `json:"includeMetadata,omitempty" bson:"includeMetadata,omitempty"`
 }
 
 type GetSiteOptionsRequest struct {
 	Filter     *SiteFilter       `json:"filter,omitempty" bson:"filter,omitempty"`
 	Pagination *CursorPagination `json:"pagination,omitempty" bson:"pagination,omitempty"`
+	Flags      *SiteFlags        `json:"flags,omitempty" bson:"flags,omitempty"`
 }
 type GetSiteOptionsResponse struct {
 	Sites []models.SiteOption `json:"sites,omitempty" bson:"sites,omitempty"`

--- a/pkg/models/site.go
+++ b/pkg/models/site.go
@@ -42,4 +42,6 @@ type SiteOption struct {
 
 	Devices []string `json:"devices" bson:"devices"`
 	Groups  []string `json:"groups" bson:"groups"`
+
+	Metadata *SiteMetadata `json:"metadata,omitempty" bson:"metadata,omitempty"`
 }

--- a/src/typescript/types.ts
+++ b/src/typescript/types.ts
@@ -7726,6 +7726,45 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/internal/siteflags": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get SiteFlags (schema generation only)
+         * @description Internal endpoint used only to ensure SiteFlags schema is generated in OpenAPI spec
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["api.SiteFlags"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/internal/sitemetadata": {
         parameters: {
             query?: never;
@@ -10023,6 +10062,7 @@ export interface components {
         };
         "api.GetSiteOptionsRequest": {
             filter?: components["schemas"]["api.SiteFilter"];
+            flags?: components["schemas"]["api.SiteFlags"];
             pagination?: components["schemas"]["api.CursorPagination"];
         };
         "api.GetSiteOptionsResponse": {
@@ -10268,6 +10308,10 @@ export interface components {
             metadata?: components["schemas"]["api.mediaMetadataPatch"];
         };
         "api.Metadata": {
+            /** @description Name of the application */
+            applicationName?: string;
+            /** @description Version of the application */
+            applicationVersion?: string;
             data?: {
                 [key: string]: unknown;
             };
@@ -10356,6 +10400,9 @@ export interface components {
         "api.SiteFilter": {
             name?: string;
             siteIds?: string[];
+        };
+        "api.SiteFlags": {
+            includeMetadata?: boolean;
         };
         "api.SubmitFaceRedactionErrorResponse": {
             /** @description Application-specific error code */
@@ -11629,6 +11676,7 @@ export interface components {
         "models.SiteOption": {
             devices?: string[];
             groups?: string[];
+            metadata?: components["schemas"]["models.SiteMetadata"];
             text?: string;
             value?: string;
         };
@@ -12111,6 +12159,7 @@ export namespace api {
     export type SaveFaceRedactionSuccessResponse = components['schemas']['api.SaveFaceRedactionSuccessResponse'];
     export type SingleSignOnDomainsResponse = components['schemas']['api.SingleSignOnDomainsResponse'];
     export type SiteFilter = components['schemas']['api.SiteFilter'];
+    export type SiteFlags = components['schemas']['api.SiteFlags'];
     export type SubmitFaceRedactionErrorResponse = components['schemas']['api.SubmitFaceRedactionErrorResponse'];
     export type SubmitFaceRedactionRequest = components['schemas']['api.SubmitFaceRedactionRequest'];
     export type SubmitFaceRedactionResponse = components['schemas']['api.SubmitFaceRedactionResponse'];


### PR DESCRIPTION
## Description

### Pull Request Description: feature/media-details

#### Motivation and Improvement

This pull request introduces the ability for clients to request optional fields in certain API payloads using the `include` parameter. Specifically, it allows site option queries to support `include: ["metadata"]` to return site metadata alongside the default fields. 

**Why This Change Improves the Project:**

1. **Enhanced Flexibility:** By enabling selective field inclusion, clients can tailor API responses to their specific needs, reducing unnecessary data transfer and improving performance.
2. **Improved Data Access:** The ability to include metadata provides clients with richer information about sites without requiring separate API calls, streamlining data access and enhancing user experience.
3. **Simplified Integration:** This feature simplifies client-side integration, as clients can request all necessary data in a single query, making the API more user-friendly and efficient.

Overall, these enhancements make the API more versatile, efficient, and user-centric, aligning with our goal of providing robust and flexible data access capabilities.