### PR TITLE
Add DurationFormatted to MediaAtRuntimeMetadata

### DIFF
--- a/pkg/models/media.go
+++ b/pkg/models/media.go
@@ -84,13 +84,14 @@ type MediaMetadata struct {
 
 // MediaAtRuntimeMetadata contains metadata that is generated at runtime, which can include
 type MediaAtRuntimeMetadata struct {
-	CachedTimestamp int64            `json:"cachedTimestamp,omitempty" bson:"cachedTimestamp,omitempty"` // Timestamp when the runtime metadata was cached.
-	VideoUrl        string           `json:"videoUrl,omitempty" bson:"videoUrl,omitempty"`
-	ThumbnailUrl    string           `json:"thumbnailUrl,omitempty" bson:"thumbnailUrl,omitempty"`
-	SpriteUrl       string           `json:"spriteUrl,omitempty" bson:"spriteUrl,omitempty"`
-	RedactionUrl    string           `json:"redactionUrl,omitempty" bson:"redactionUrl,omitempty"`
-	Analysis        *AnalysisWrapper `json:"analysis,omitempty" bson:"analysis,omitempty"`
-	Device          *Device          `json:"device,omitempty" bson:"device,omitempty"`
+	CachedTimestamp   int64            `json:"cachedTimestamp,omitempty" bson:"cachedTimestamp,omitempty"` // Timestamp when the runtime metadata was cached.
+	VideoUrl          string           `json:"videoUrl,omitempty" bson:"videoUrl,omitempty"`
+	ThumbnailUrl      string           `json:"thumbnailUrl,omitempty" bson:"thumbnailUrl,omitempty"`
+	SpriteUrl         string           `json:"spriteUrl,omitempty" bson:"spriteUrl,omitempty"`
+	RedactionUrl      string           `json:"redactionUrl,omitempty" bson:"redactionUrl,omitempty"`
+	Analysis          *AnalysisWrapper `json:"analysis,omitempty" bson:"analysis,omitempty"`
+	Device            *Device          `json:"device,omitempty" bson:"device,omitempty"`
+	DurationFormatted string           `json:"durationFormatted,omitempty" bson:"durationFormatted,omitempty"`
 }
 
 type Region struct {


### PR DESCRIPTION
## Description

### Pull Request: Add DurationFormatted to MediaAtRuntimeMetadata

#### Motivation

The primary motivation behind this change is to enhance the `MediaAtRuntimeMetadata` structure by including a formatted duration string. This addition aims to improve the user experience by providing a human-readable format of the media duration, which is often more informative and user-friendly than raw numerical values.

#### Why It Improves the Project

1. **Enhanced Data Representation**: Adding the `DurationFormatted` field allows for a more intuitive display of media duration. This formatted string can be directly used in user interfaces, making it easier for users to understand the length of the media without needing to interpret raw duration values.

2. **Consistency**: Including a formatted duration within the metadata ensures that all relevant information about the media is encapsulated within the same structure. This consistency simplifies data handling and reduces the need for additional formatting logic in different parts of the codebase.

3. **User Experience**: By presenting a readable duration format, we enhance the overall user experience. Users can quickly grasp the duration of media content, improving interaction with the application.

4. **Future Extensions**: This change lays the groundwork for future enhancements where additional formatted or user-friendly metadata can be added, further enriching the `MediaAtRuntimeMetadata` structure.

Overall, this change is a straightforward yet impactful improvement that aligns with our goals of providing a better user experience and maintaining a consistent and comprehensive data structure.