### PR TITLE
feature/integrate-analysis-into-media

### DIFF
--- a/pkg/models/media.go
+++ b/pkg/models/media.go
@@ -185,3 +185,9 @@ type CountingSummary struct {
 	Count    int     `json:"count" bson:"count"`
 	Duration float64 `json:"duration,omitempty" bson:"duration,omitempty"`
 }
+
+const (
+	CountingIn     = "counting-in"
+	CountingOut    = "counting-out"
+	CountingRegion = "counting-region"
+)


### PR DESCRIPTION
## Description

### Pull Request Description

**Title**: feature/integrate-analysis-into-media

**Motivation**:
The purpose of this change is to integrate analysis constants directly into the media model, which improves the project's structure and maintainability. By defining these constants within the media model, we centralize their definitions, making the codebase easier to understand and modify.

**Changes**:
- Added three constants (`CountingIn`, `CountingOut`, `CountingRegion`) to the `media.go` file.
  
**Why It Improves the Project**:
1. **Centralization**: By placing these constants within the media model, we ensure that all related definitions are centralized. This reduces the chances of discrepancies and miscommunication across different parts of the codebase.
2. **Maintainability**: With a centralized location for these constants, future changes can be made more easily and with less risk of introducing errors.
3. **Clarity**: This change enhances the readability of the code. Future developers will find it easier to understand the role of these constants within the media context.

Overall, this enhancement contributes to a more organized and maintainable codebase, facilitating future development and collaboration.