### PR TITLE
Update CountingSummary constants to camelCase

### DIFF
--- a/pkg/models/media.go
+++ b/pkg/models/media.go
@@ -187,7 +187,7 @@ type CountingSummary struct {
 }
 
 const (
-	CountingIn     = "counting-in"
-	CountingOut    = "counting-out"
-	CountingRegion = "counting-region"
+	CountingIn     = "countingIn"
+	CountingOut    = "countingOut"
+	CountingRegion = "countingRegion"
 )


### PR DESCRIPTION
## Description

### Pull Request Description: Update CountingSummary Constants to camelCase

#### Motivation:
The primary motivation behind this change is to improve the consistency and readability of our codebase by adhering to the camelCase naming convention for constants. CamelCase is widely used in Go and helps to maintain a clean, standardized code style across the project.

#### Why It Improves the Project:
1. **Consistency**: By updating the `CountingSummary` constants to camelCase, we ensure that our code follows a consistent naming convention, making it easier for developers to read and understand.
2. **Readability**: CamelCase improves the readability of the code by clearly distinguishing individual words within the constant names. This is particularly useful for longer names where hyphens can be less visually appealing.
3. **Standardization**: Adhering to common conventions and best practices in Go helps new contributors quickly familiarize themselves with the codebase, reducing the learning curve and improving collaboration.

#### Changes:
- Updated the `CountingSummary` constants from kebab-case to camelCase:
  - `CountingIn` from `counting-in`
  - `CountingOut` from `counting-out`
  - `CountingRegion` from `counting-region`

These changes are applied across the `pkg/models/media.go` file, ensuring that all instances of these constants are updated consistently.

By making these changes, we enhance the maintainability and professionalism of our codebase, aligning with Go's standard practices.