### PR TITLE
Add media handling to task operations with new request and response

### DIFF
--- a/pkg/api/task.go
+++ b/pkg/api/task.go
@@ -1,6 +1,9 @@
 package api
 
-import "github.com/uug-ai/models/pkg/models"
+import (
+	"github.com/uug-ai/models/pkg/models"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
 
 // TaskStatus represents specific status codes for task operations
 type TaskStatus string
@@ -82,5 +85,215 @@ type AddTaskMediaSuccessResponse struct {
 }
 
 type AddTaskMediaErrorResponse struct {
+	ErrorResponse
+}
+
+// TaskIdRequest represents task endpoints that identify a task by URI id.
+type TaskIdRequest struct {
+	Id string `uri:"id" json:"id,omitempty" bson:"id,omitempty"`
+}
+
+// TaskCommentIdRequest represents comment endpoints scoped to a task.
+type TaskCommentIdRequest struct {
+	Id        string `uri:"id" json:"id,omitempty" bson:"id,omitempty"`
+	CommentId string `uri:"comment_id" json:"commentId,omitempty" bson:"commentId,omitempty"`
+}
+
+// GetTasksRequest captures query parameters for GET /tasks.
+type GetTasksRequest struct {
+	Limit int `form:"limit,omitempty" json:"limit,omitempty" bson:"limit,omitempty"`
+}
+
+// TaskFilter defines filtering options for listing tasks.
+type TaskFilter struct {
+	TaskIds   []string `json:"taskIds,omitempty" bson:"taskIds,omitempty"`
+	Title     string   `json:"title" bson:"title,omitempty"`
+	View      string   `json:"view" bson:"view,omitempty"` // "full" (default) or "compact"
+	Limit     int      `json:"limit" bson:"limit,omitempty"`
+	Sites     []string `json:"sites" bson:"sites,omitempty"`
+	Devices   []string `json:"devices" bson:"devices,omitempty"`
+	Groups    []string `json:"groups" bson:"groups,omitempty"`
+	Assignees []string `json:"assignees" bson:"assignees,omitempty"`
+	Labels    []string `json:"labels" bson:"labels,omitempty"`
+	Status    []string `json:"status" bson:"status,omitempty"`
+	Offset    int      `json:"offset" bson:"offset,omitempty"`
+}
+
+// GetTasksResponse represents task list payloads returned by list endpoints.
+type GetTasksResponse struct {
+	Tasks []models.Task `json:"tasks,omitempty" bson:"tasks,omitempty"`
+}
+
+type GetTasksSuccessResponse struct {
+	SuccessResponse
+	Data GetTasksResponse `json:"data,omitempty" bson:"data,omitempty"`
+}
+
+type GetTasksErrorResponse struct {
+	ErrorResponse
+}
+
+// GetTasksFilteredRequest matches POST /tasks/filter request body.
+// The endpoint receives the filter object directly.
+type GetTasksFilteredRequest = TaskFilter
+
+// GetTasksFilteredQuery captures query parameters for POST /tasks/filter.
+type GetTasksFilteredQuery struct {
+	Limit int `form:"limit,omitempty" json:"limit,omitempty" bson:"limit,omitempty"`
+}
+
+// TaskCompact is used by lightweight task pickers that only need summary fields.
+type TaskCompact struct {
+	Id               primitive.ObjectID `json:"id,omitempty" bson:"_id,omitempty"`
+	CreationDate     int64         `json:"creation_date,omitempty" bson:"creation_date,omitempty"`
+	CreationDateTime string        `json:"creation_datetime,omitempty" bson:"creation_datetime,omitempty"`
+	Title            string        `json:"title,omitempty" bson:"title,omitempty"`
+	Status           string        `json:"status,omitempty" bson:"status,omitempty"`
+	IsPrivate        bool          `json:"is_private,omitempty" bson:"is_private,omitempty"`
+}
+
+type GetTasksFilteredResponse struct {
+	Tasks []models.Task `json:"tasks,omitempty" bson:"tasks,omitempty"`
+}
+
+type GetTasksCompactResponse struct {
+	Tasks []TaskCompact `json:"tasks,omitempty" bson:"tasks,omitempty"`
+}
+
+type GetTasksFilteredSuccessResponse struct {
+	SuccessResponse
+	Data GetTasksFilteredResponse `json:"data,omitempty" bson:"data,omitempty"`
+}
+
+type GetTasksFilteredErrorResponse struct {
+	ErrorResponse
+}
+
+type GetTaskStatisticsResponse struct {
+	Statistics models.TaskStatistics `json:"statistics,omitempty" bson:"statistics,omitempty"`
+}
+
+type GetTaskStatisticsSuccessResponse struct {
+	SuccessResponse
+	Data GetTaskStatisticsResponse `json:"data,omitempty" bson:"data,omitempty"`
+}
+
+type GetTaskStatisticsErrorResponse struct {
+	ErrorResponse
+}
+
+// AddTaskRequest wraps the task payload used by POST /tasks.
+// The task payload can optionally include mediaFilter for server-side export file resolution.
+type AddTaskRequest struct {
+	Task AddTaskPayload `json:"task" bson:"task"`
+}
+
+// AddTaskPayload mirrors models.Task while allowing transport-level options.
+type AddTaskPayload struct {
+	models.Task `bson:",inline"`
+	MediaFilter *MediaFilter `json:"mediaFilter,omitempty" bson:"mediaFilter,omitempty"`
+}
+
+type AddTaskResponse struct {
+	Task  models.Task   `json:"task,omitempty" bson:"task,omitempty"`
+	Tasks []models.Task `json:"tasks,omitempty" bson:"tasks,omitempty"`
+}
+
+type AddTaskSuccessResponse struct {
+	SuccessResponse
+	Data AddTaskResponse `json:"data,omitempty" bson:"data,omitempty"`
+}
+
+type AddTaskErrorResponse struct {
+	ErrorResponse
+}
+
+// EditTaskRequest matches PATCH /tasks/{id} request payload.
+// It intentionally remains dynamic because patchable fields vary.
+type EditTaskRequest map[string]interface{}
+
+type EditTaskResponse struct {
+	UpdatedFields map[string]interface{} `json:"updatedFields,omitempty" bson:"updatedFields,omitempty"`
+}
+
+type EditTaskSuccessResponse struct {
+	SuccessResponse
+	Data EditTaskResponse `json:"data,omitempty" bson:"data,omitempty"`
+}
+
+type EditTaskErrorResponse struct {
+	ErrorResponse
+}
+
+type DeleteTaskResponse struct {
+	Task models.Task `json:"task,omitempty" bson:"task,omitempty"`
+}
+
+type DeleteTaskSuccessResponse struct {
+	SuccessResponse
+	Data DeleteTaskResponse `json:"data,omitempty" bson:"data,omitempty"`
+}
+
+type DeleteTaskErrorResponse struct {
+	ErrorResponse
+}
+
+type GetTaskCommentsResponse struct {
+	Comments []models.Comment `json:"comments,omitempty" bson:"comments,omitempty"`
+}
+
+type GetTaskCommentsSuccessResponse struct {
+	SuccessResponse
+	Data GetTaskCommentsResponse `json:"data,omitempty" bson:"data,omitempty"`
+}
+
+type GetTaskCommentsErrorResponse struct {
+	ErrorResponse
+}
+
+type AddTaskCommentRequest struct {
+	Comment models.Comment `json:"comment" bson:"comment"`
+}
+
+type AddTaskCommentResponse struct {
+	Comment models.Comment `json:"comment,omitempty" bson:"comment,omitempty"`
+}
+
+type AddTaskCommentSuccessResponse struct {
+	SuccessResponse
+	Data AddTaskCommentResponse `json:"data,omitempty" bson:"data,omitempty"`
+}
+
+type AddTaskCommentErrorResponse struct {
+	ErrorResponse
+}
+
+type EditTaskCommentRequest struct {
+	Comment models.Comment `json:"comment" bson:"comment"`
+}
+
+type EditTaskCommentResponse struct {
+	Comment models.Comment `json:"comment,omitempty" bson:"comment,omitempty"`
+}
+
+type EditTaskCommentSuccessResponse struct {
+	SuccessResponse
+	Data EditTaskCommentResponse `json:"data,omitempty" bson:"data,omitempty"`
+}
+
+type EditTaskCommentErrorResponse struct {
+	ErrorResponse
+}
+
+type DeleteTaskCommentResponse struct {
+	Message string `json:"message,omitempty" bson:"message,omitempty"`
+}
+
+type DeleteTaskCommentSuccessResponse struct {
+	SuccessResponse
+	Data DeleteTaskCommentResponse `json:"data,omitempty" bson:"data,omitempty"`
+}
+
+type DeleteTaskCommentErrorResponse struct {
 	ErrorResponse
 }

--- a/pkg/api/task.go
+++ b/pkg/api/task.go
@@ -1,20 +1,24 @@
 package api
 
+import "github.com/uug-ai/models/pkg/models"
+
 // TaskStatus represents specific status codes for task operations
 type TaskStatus string
 
 const (
-	TaskBindingFailed TaskStatus = "Task_binding_failed"
-	TaskDuplicateName TaskStatus = "Task_duplicate_name"
-	TaskMissingInfo   TaskStatus = "Task_missing_info"
-	TaskFound         TaskStatus = "Task_found"
-	TaskNotFound      TaskStatus = "Task_not_found"
-	TaskAddSuccess    TaskStatus = "Task_add_success"
-	TaskAddFailed     TaskStatus = "Task_add_failed"
-	TaskUpdateSuccess TaskStatus = "Task_update_success"
-	TaskUpdateFailed  TaskStatus = "Task_update_failed"
-	TaskDeleteSuccess TaskStatus = "Task_delete_success"
-	TaskDeleteFailed  TaskStatus = "Task_delete_failed"
+	TaskBindingFailed   TaskStatus = "Task_binding_failed"
+	TaskDuplicateName   TaskStatus = "Task_duplicate_name"
+	TaskMissingInfo     TaskStatus = "Task_missing_info"
+	TaskFound           TaskStatus = "Task_found"
+	TaskNotFound        TaskStatus = "Task_not_found"
+	TaskAddSuccess      TaskStatus = "Task_add_success"
+	TaskAddFailed       TaskStatus = "Task_add_failed"
+	TaskUpdateSuccess   TaskStatus = "Task_update_success"
+	TaskUpdateFailed    TaskStatus = "Task_update_failed"
+	TaskDeleteSuccess   TaskStatus = "Task_delete_success"
+	TaskDeleteFailed    TaskStatus = "Task_delete_failed"
+	TaskMediaAddSuccess TaskStatus = "Task_media_add_success"
+	TaskMediaAddFailed  TaskStatus = "Task_media_add_failed"
 )
 
 // String returns the string representation of the Task status
@@ -37,6 +41,8 @@ func (ms TaskStatus) Translate(lang string) string {
 			TaskUpdateFailed:  "Task failed to update",
 			TaskDeleteSuccess: "Task deleted successfully",
 			TaskDeleteFailed:  "Task failed to delete",
+			TaskMediaAddSuccess: "Media was added to the task successfully",
+			TaskMediaAddFailed:  "Failed to add media to the task",
 		},
 	}
 
@@ -55,4 +61,26 @@ func (ms TaskStatus) Translate(lang string) string {
 
 	// Fallback to the string representation
 	return ms.String()
+}
+
+// AddTaskMediaRequest is used by POST /tasks/{id}/media to attach one or more media
+// items to an existing task.
+type AddTaskMediaRequest struct {
+	MediaIds []string `json:"mediaIds,omitempty" bson:"mediaIds,omitempty"`
+}
+
+// AddTaskMediaResponse returns the updated task and which media IDs were added or skipped.
+type AddTaskMediaResponse struct {
+	Task            models.Task `json:"task,omitempty" bson:"task,omitempty"`
+	AddedMediaIds   []string    `json:"addedMediaIds,omitempty" bson:"addedMediaIds,omitempty"`
+	SkippedMediaIds []string    `json:"skippedMediaIds,omitempty" bson:"skippedMediaIds,omitempty"`
+}
+
+type AddTaskMediaSuccessResponse struct {
+	SuccessResponse
+	Data AddTaskMediaResponse `json:"data,omitempty" bson:"data,omitempty"`
+}
+
+type AddTaskMediaErrorResponse struct {
+	ErrorResponse
 }

--- a/pkg/models/comment.go
+++ b/pkg/models/comment.go
@@ -21,3 +21,7 @@ type Comment struct {
 	// Audit information
 	Audit *Audit `json:"audit,omitempty" bson:"audit,omitempty"`
 }
+
+type CommentWrapper struct {
+	Comment Comment `json:"comment" bson:"comment"`
+}

--- a/pkg/models/task.go
+++ b/pkg/models/task.go
@@ -13,6 +13,13 @@ type TaskWrapper struct {
 	Task Task `json:"task" bson:"task"`
 }
 
+type TaskStatistics struct {
+	Open     int64 `json:"open" bson:"open"`
+	Rejected int64 `json:"rejected" bson:"rejected"`
+	Approved int64 `json:"approved" bson:"approved"`
+	Total    int64 `json:"total" bson:"total"`
+}
+
 type Task struct {
 	Id                primitive.ObjectID `json:"id" bson:"_id,omitempty,omitempty"`
 	CreationDate      int64              `json:"creation_date" bson:"creation_date,omitempty"`
@@ -73,19 +80,6 @@ type Task struct {
 	// Related collections
 	Comments []Comment `json:"comments" bson:"comments,omitempty"`
 	Labels   []string  `json:"labels" bson:"labels,omitempty"`
-}
-
-type TaskFilter struct {
-	Title     string   `json:"title" bson:"title,omitempty"`
-	View      string   `json:"view" bson:"view,omitempty"` // "full" (default) or "compact"
-	Limit     int      `json:"limit" bson:"limit,omitempty"`
-	Sites     []string `json:"sites" bson:"sites,omitempty"`
-	Devices   []string `json:"devices" bson:"devices,omitempty"`
-	Groups    []string `json:"groups" bson:"groups,omitempty"`
-	Assignees []string `json:"assignees" bson:"assignees,omitempty"`
-	Labels    []string `json:"labels" bson:"labels,omitempty"`
-	Status    []string `json:"status" bson:"status,omitempty"`
-	Offset    int      `json:"offset" bson:"offset,omitempty"`
 }
 
 type ExportFile struct {

--- a/pkg/models/task.go
+++ b/pkg/models/task.go
@@ -77,6 +77,7 @@ type Task struct {
 
 type TaskFilter struct {
 	Title     string   `json:"title" bson:"title,omitempty"`
+	View      string   `json:"view" bson:"view,omitempty"` // "full" (default) or "compact"
 	Limit     int      `json:"limit" bson:"limit,omitempty"`
 	Sites     []string `json:"sites" bson:"sites,omitempty"`
 	Devices   []string `json:"devices" bson:"devices,omitempty"`


### PR DESCRIPTION
## Description

## Motivation & Impact

Tasks currently lack a first-class way to attach and manage media, which limits workflows that depend on associating files (images, videos, exports) with task execution and review. This gap forces media handling to live outside the task lifecycle, making APIs harder to use and results harder to reason about.

This PR introduces explicit media handling into task operations by adding dedicated request/response models and status codes for attaching media to existing tasks. It also consolidates and expands task-related API models (filters, compact views, statistics) to better support scalable querying and reporting use cases.

**Why this improves the project**
- Enables a clear, consistent API for adding media to tasks, aligned with existing task semantics.
- Improves API expressiveness with explicit success/failure states for media operations.
- Lays the foundation for richer task workflows (review, approval, exports) without breaking existing contracts.
- Centralizes and cleans up task filtering and statistics models, reducing duplication and ambiguity.

Overall, this makes task APIs more complete, extensible, and easier to integrate with media-driven features.