### PR TITLE
add ThumbnailUrl to compact task

### DIFF
--- a/pkg/api/task.go
+++ b/pkg/api/task.go
@@ -179,6 +179,7 @@ type TaskCompact struct {
 	Title            string        `json:"title,omitempty" bson:"title,omitempty"`
 	Status           string        `json:"status,omitempty" bson:"status,omitempty"`
 	IsPrivate        bool          `json:"is_private,omitempty" bson:"is_private,omitempty"`
+	ThumbnailUrl     string        `json:"thumbnail_url,omitempty" bson:"thumbnail_url,omitempty"`
 }
 
 type GetTasksFilteredResponse struct {


### PR DESCRIPTION
## Description

This change adds `ThumbnailUrl` to the `TaskCompact` API model to support richer task representations in list and compact views.

The motivation is to allow clients (especially UI consumers) to display task thumbnails without requiring additional API calls or fetching the full task payload. By including this field in the compact response, we reduce over-fetching, simplify client logic, and improve performance while keeping backward compatibility thanks to the optional field.