### PR TITLE
Add video to export files

### DIFF
--- a/pkg/models/task.go
+++ b/pkg/models/task.go
@@ -88,11 +88,14 @@ type ExportFile struct {
 	CameraId          string `json:"camera_id" bson:"camera_id,omitempty"`
 	Provider          string `json:"provider" bson:"provider,omitempty"`
 	Source            string `json:"source" bson:"source,omitempty"`
+	VideoUrl          string `json:"video_url,omitempty" bson:"video_url,omitempty"`
 	SpriteFile        string `json:"spriteFile" bson:"spriteFile"`
 	SpriteProvider    string `json:"spriteProvider" bson:"spriteProvider"`
+	SpriteUrl         string `json:"sprite_url,omitempty" bson:"sprite_url,omitempty"`
 	SpriteInterval    int    `json:"spriteInterval" bson:"spriteInterval"`
 	ThumbnailFile     string `json:"thumbnailFile" bson:"thumbnailFile"`
 	ThumbnailProvider string `json:"thumbnailProvider" bson:"thumbnailProvider"`
+	ThumbnailUrl      string `json:"thumbnail_url,omitempty" bson:"thumbnail_url,omitempty"`
 }
 
 type MediaWrapper struct {


### PR DESCRIPTION
## Description

**Motivation & Impact**

Export files currently expose only internal file names/providers, which makes it hard for consumers to directly access the generated media without additional resolution logic. This PR adds explicit URLs for the exported video, sprite, and thumbnail.

By including `video_url`, `sprite_url`, and `thumbnail_url` in the export model, downstream services and clients can directly consume exported media in a consistent and self-contained way. This improves API usability, reduces coupling to storage/provider-specific logic, and makes exports easier to integrate and display.