### PR TITLE
feature/add-byte-ranges-to-media

### DIFF
--- a/pkg/models/media.go
+++ b/pkg/models/media.go
@@ -24,9 +24,11 @@ type Media struct {
 
 	// Media file information (by default "vault", however might change
 	// in the future (integration with other storage solutions, next to Vault).
-	StorageSolution   string `json:"storageSolution,omitempty" bson:"storageSolution,omitempty"`
-	VideoFile         string `json:"videoFile,omitempty" bson:"videoFile,omitempty"`
-	VideoProvider     string `json:"videoProvider,omitempty" bson:"videoProvider,omitempty"`
+	StorageSolution       string                  `json:"storageSolution,omitempty" bson:"storageSolution,omitempty"`
+	VideoFile             string                  `json:"videoFile,omitempty" bson:"videoFile,omitempty"`
+	VideoProvider         string                  `json:"videoProvider,omitempty" bson:"videoProvider,omitempty"`
+	VideoBytesRangeOnTime []VideoBytesRangeOnTime `json:"videooBytesRangeOnTime,omitempty"  bson:"videooBytesRangeOnTime,omitempty"`
+
 	ThumbnailFile     string `json:"thumbnailFile,omitempty" bson:"thumbnailFile,omitempty"`
 	ThumbnailProvider string `json:"thumbnailProvider,omitempty" bson:"thumbnailProvider,omitempty"`
 	SpriteFile        string `json:"spriteFile,omitempty" bson:"spriteFile,omitempty"`

--- a/pkg/models/mp4.go
+++ b/pkg/models/mp4.go
@@ -5,3 +5,9 @@ type FragmentedBytesRangeOnTime struct {
 	Time     string `json:"time" bson:"time"`
 	Range    string `json:"range" bson:"range"`
 }
+
+type VideoBytesRangeOnTime struct {
+	Duration string `json:"duration" bson:"duration"`
+	Time     string `json:"time" bson:"time"`
+	Range    string `json:"range" bson:"range"`
+}


### PR DESCRIPTION
## Description

### Motivation

We currently lack a way to represent byte ranges tied to playback time for video media. This limits our ability to support efficient streaming use cases such as partial content delivery, seeking, or time-based fetching without downloading the entire file.

### Why this improves the project

This PR introduces time-based byte range metadata to the `Media` model, making it possible to map video segments (duration/time) directly to byte ranges. This lays the foundation for proper byte-range requests, more efficient video streaming, and better integration with fragmented media formats. The change is backward-compatible and purely additive, enabling future features without impacting existing consumers.