### PR TITLE
Add 'star' field to MediaPatch and Media models for media favoritism

### DIFF
--- a/pkg/api/media.go
+++ b/pkg/api/media.go
@@ -98,6 +98,7 @@ type MediaFilter struct {
 
 type MediaPatch struct {
 	Metadata *MediaMetadataPatch `json:"metadata,omitempty" bson:"metadata,omitempty"`
+	Star     *bool               `json:"star,omitempty" bson:"star,omitempty"`
 }
 
 type MediaMetadataPatch struct {

--- a/pkg/models/media.go
+++ b/pkg/models/media.go
@@ -12,6 +12,7 @@ type Media struct {
 	StartTimestamp int64 `json:"startTimestamp,omitempty" bson:"startTimestamp,omitempty"`
 	EndTimestamp   int64 `json:"endTimestamp,omitempty" bson:"endTimestamp,omitempty"`
 	Duration       int   `json:"duration,omitempty" bson:"duration,omitempty"`
+	Star           bool  `json:"star,omitempty" bson:"star,omitempty"`
 
 	// RBAC information
 	// DeviceId is a unique identifier for the device, it can be used to identify the device in the system.


### PR DESCRIPTION
## Description

This change introduces a `star` field to both the `Media` model and the `MediaPatch` API to support media favoritism.

Previously, there was no first-class way to mark media items as favorites, which limited user-driven organization and personalization features. Adding `star` directly to the core model makes favoritism an explicit, persistent property rather than an implicit or external concern.

Using a pointer in `MediaPatch` allows partial updates without breaking existing behavior, while the boolean field in `Media` keeps reads simple and consistent. This improves API clarity, enables new UX features (favorites, filtering, prioritization), and lays a clean foundation for future enhancements around media curation.