### PR TITLE
fix/typo-in-variable-bytesrangeontime

### DIFF
--- a/pkg/models/media.go
+++ b/pkg/models/media.go
@@ -28,7 +28,7 @@ type Media struct {
 	StorageSolution       string                  `json:"storageSolution,omitempty" bson:"storageSolution,omitempty"`
 	VideoFile             string                  `json:"videoFile,omitempty" bson:"videoFile,omitempty"`
 	VideoProvider         string                  `json:"videoProvider,omitempty" bson:"videoProvider,omitempty"`
-	VideoBytesRangeOnTime []VideoBytesRangeOnTime `json:"videooBytesRangeOnTime,omitempty"  bson:"videooBytesRangeOnTime,omitempty"`
+	VideoBytesRangeOnTime []VideoBytesRangeOnTime `json:"videoBytesRangeOnTime,omitempty"  bson:"videoBytesRangeOnTime,omitempty"`
 
 	ThumbnailFile     string `json:"thumbnailFile,omitempty" bson:"thumbnailFile,omitempty"`
 	ThumbnailProvider string `json:"thumbnailProvider,omitempty" bson:"thumbnailProvider,omitempty"`


### PR DESCRIPTION
## Description

### Motivation

The `Media` model contains a typo in the JSON/BSON field name (`videooBytesRangeOnTime`), which causes incorrect serialization/deserialization. This makes the field inconsistent with its Go struct name and breaks compatibility with clients and persisted data expecting the correct key.

### Why this improves the project

Fixing this typo aligns the struct tags with the intended API contract, ensuring data is correctly marshaled/unmarshaled and reducing the risk of subtle bugs in data exchange, storage, and downstream consumers. This is a low-risk change that improves correctness and maintainability.