### PR TITLE
Add CaseShare model and related input/output types

### DIFF
--- a/pkg/api/task.go
+++ b/pkg/api/task.go
@@ -34,18 +34,18 @@ func (ms TaskStatus) String() string {
 func (ms TaskStatus) Translate(lang string) string {
 	translations := map[string]map[TaskStatus]string{
 		"en": {
-			TaskBindingFailed: "Task binding failed",
-			TaskDuplicateName: "Task duplicate name",
-			TaskMissingInfo:   "Task missing information",
-			TaskFound:         "Task found",
-			TaskNotFound:      "Task not found",
-			TaskForbidden:     "You are not allowed to access this task",
-			TaskAddSuccess:    "Task added successfully",
-			TaskAddFailed:     "Task failed to add",
-			TaskUpdateSuccess: "Task updated successfully",
-			TaskUpdateFailed:  "Task failed to update",
-			TaskDeleteSuccess: "Task deleted successfully",
-			TaskDeleteFailed:  "Task failed to delete",
+			TaskBindingFailed:   "Task binding failed",
+			TaskDuplicateName:   "Task duplicate name",
+			TaskMissingInfo:     "Task missing information",
+			TaskFound:           "Task found",
+			TaskNotFound:        "Task not found",
+			TaskForbidden:       "You are not allowed to access this task",
+			TaskAddSuccess:      "Task added successfully",
+			TaskAddFailed:       "Task failed to add",
+			TaskUpdateSuccess:   "Task updated successfully",
+			TaskUpdateFailed:    "Task failed to update",
+			TaskDeleteSuccess:   "Task deleted successfully",
+			TaskDeleteFailed:    "Task failed to delete",
 			TaskMediaAddSuccess: "Media was added to the task successfully",
 			TaskMediaAddFailed:  "Failed to add media to the task",
 		},
@@ -231,14 +231,18 @@ type GetTaskMediaErrorResponse struct {
 	ErrorResponse
 }
 
+type GetTaskMediaRequestBody struct {
+	Pagination CursorPagination `json:"pagination,omitempty" bson:"pagination,omitempty"`
+}
+
 // GetTasksFilteredRequest matches POST /tasks/filter request body.
 // It supports both:
 // - legacy direct filters: { title, status, limit, offset, ... }
 // - preferred wrapped form: { filter: {...}, pagination: { cursor, limit } }
 type GetTasksFilteredRequest struct {
-	TaskFilter  `bson:",inline"`
-	Filter      *TaskFilter       `json:"filter,omitempty" bson:"filter,omitempty"`
-	Pagination  *CursorPagination `json:"pagination,omitempty" bson:"pagination,omitempty"`
+	TaskFilter `bson:",inline"`
+	Filter     *TaskFilter       `json:"filter,omitempty" bson:"filter,omitempty"`
+	Pagination *CursorPagination `json:"pagination,omitempty" bson:"pagination,omitempty"`
 }
 
 // GetTasksFilteredQuery captures query parameters for POST /tasks/filter.
@@ -249,12 +253,12 @@ type GetTasksFilteredQuery struct {
 // TaskCompact is used by lightweight task pickers that only need summary fields.
 type TaskCompact struct {
 	Id               primitive.ObjectID `json:"id,omitempty" bson:"_id,omitempty"`
-	CreationDate     int64         `json:"creation_date,omitempty" bson:"creation_date,omitempty"`
-	CreationDateTime string        `json:"creation_datetime,omitempty" bson:"creation_datetime,omitempty"`
-	Title            string        `json:"title,omitempty" bson:"title,omitempty"`
-	Status           string        `json:"status,omitempty" bson:"status,omitempty"`
-	IsPrivate        bool          `json:"is_private,omitempty" bson:"is_private,omitempty"`
-	ThumbnailUrl     string        `json:"thumbnail_url,omitempty" bson:"thumbnail_url,omitempty"`
+	CreationDate     int64              `json:"creation_date,omitempty" bson:"creation_date,omitempty"`
+	CreationDateTime string             `json:"creation_datetime,omitempty" bson:"creation_datetime,omitempty"`
+	Title            string             `json:"title,omitempty" bson:"title,omitempty"`
+	Status           string             `json:"status,omitempty" bson:"status,omitempty"`
+	IsPrivate        bool               `json:"is_private,omitempty" bson:"is_private,omitempty"`
+	ThumbnailUrl     string             `json:"thumbnail_url,omitempty" bson:"thumbnail_url,omitempty"`
 }
 
 type GetTasksFilteredResponse struct {
@@ -326,12 +330,12 @@ type AddTaskErrorResponse struct {
 // It includes only fields currently editable from the frontend task UI.
 type EditTaskRequest struct {
 	Status           *TaskStatus `json:"status,omitempty" bson:"status,omitempty"`
-	Notes            *string   `json:"notes,omitempty" bson:"notes,omitempty"`
-	Labels           *[]string `json:"labels,omitempty" bson:"labels,omitempty"`
-	Assignees        *[]string `json:"assignees,omitempty" bson:"assignees,omitempty"`
-	AssigneesProfile *[]string `json:"assignees_profile,omitempty" bson:"assignees_profile,omitempty"`
-	NotifyAssignees  *bool     `json:"notify_assignees,omitempty" bson:"notify_assignees,omitempty"`
-	IsPrivate        *bool     `json:"is_private,omitempty" bson:"is_private,omitempty"`
+	Notes            *string     `json:"notes,omitempty" bson:"notes,omitempty"`
+	Labels           *[]string   `json:"labels,omitempty" bson:"labels,omitempty"`
+	Assignees        *[]string   `json:"assignees,omitempty" bson:"assignees,omitempty"`
+	AssigneesProfile *[]string   `json:"assignees_profile,omitempty" bson:"assignees_profile,omitempty"`
+	NotifyAssignees  *bool       `json:"notify_assignees,omitempty" bson:"notify_assignees,omitempty"`
+	IsPrivate        *bool       `json:"is_private,omitempty" bson:"is_private,omitempty"`
 }
 
 type EditTaskResponse struct {

--- a/pkg/api/task.go
+++ b/pkg/api/task.go
@@ -231,10 +231,6 @@ type GetTaskMediaErrorResponse struct {
 	ErrorResponse
 }
 
-type GetTaskMediaRequestBody struct {
-	Pagination CursorPagination `json:"pagination,omitempty" bson:"pagination,omitempty"`
-}
-
 // GetTasksFilteredRequest matches POST /tasks/filter request body.
 // It supports both:
 // - legacy direct filters: { title, status, limit, offset, ... }

--- a/pkg/models/case_share.go
+++ b/pkg/models/case_share.go
@@ -3,19 +3,20 @@ package models
 import "go.mongodb.org/mongo-driver/bson/primitive"
 
 type CaseShare struct {
-	Id          primitive.ObjectID `json:"id" bson:"_id,omitempty"`
-	TaskId      string             `json:"task_id" bson:"task_id"`
-	OwnerId     string             `json:"owner_id" bson:"owner_id"`
-	OwnerEmail  string             `json:"owner_email" bson:"owner_email"`
-	Email       string             `json:"email" bson:"email"`
-	Token       string             `json:"token" bson:"token"`
-	Permissions []string           `json:"permissions" bson:"permissions"` // e.g. ["view"]
-	IsActive    bool               `json:"is_active" bson:"is_active"`
-	ExpiresAt   int64              `json:"expires_at" bson:"expires_at"`
-	CreatedAt   int64              `json:"created_at" bson:"created_at"`
-	OTPCode     string             `json:"-" bson:"otp_code,omitempty"`
-	OTPExpiry   int64              `json:"-" bson:"otp_expiry,omitempty"`
-	OTPAttempts int                `json:"-" bson:"otp_attempts,omitempty"`
+	Id             primitive.ObjectID `json:"id" bson:"_id,omitempty"`
+	TaskId         string             `json:"task_id" bson:"task_id"`
+	UserId         string             `json:"user_id" bson:"user_id"`
+	UserEmail      string             `json:"user_email" bson:"user_email"`
+	OrganisationId string             `json:"organisation_id" bson:"organisation_id"`
+	Email          string             `json:"email" bson:"email"`
+	Token          string             `json:"token" bson:"token"`
+	Permissions    []string           `json:"permissions" bson:"permissions"` // e.g. ["view"]
+	IsActive       bool               `json:"is_active" bson:"is_active"`
+	ExpiresAt      int64              `json:"expires_at" bson:"expires_at"`
+	CreatedAt      int64              `json:"created_at" bson:"created_at"`
+	OTPCode        string             `json:"-" bson:"otp_code,omitempty"`
+	OTPExpiry      int64              `json:"-" bson:"otp_expiry,omitempty"`
+	OTPAttempts    int                `json:"-" bson:"otp_attempts,omitempty"`
 }
 
 // Input/Output types for repository operations
@@ -35,8 +36,8 @@ type GetCaseShareByTokenOutput struct {
 }
 
 type GetCaseSharesForTaskInput struct {
-	TaskId  string `json:"task_id"`
-	OwnerId string `json:"owner_id"`
+	TaskId string `json:"task_id"`
+	UserId string `json:"user_id"`
 }
 type GetCaseSharesForTaskOutput struct {
 	Shares []CaseShare `json:"shares"`
@@ -44,6 +45,6 @@ type GetCaseSharesForTaskOutput struct {
 
 type DeleteCaseShareInput struct {
 	ShareId string `json:"share_id"`
-	OwnerId string `json:"owner_id"`
+	UserId  string `json:"user_id"`
 }
 type DeleteCaseShareOutput struct{}

--- a/pkg/models/case_share.go
+++ b/pkg/models/case_share.go
@@ -1,0 +1,49 @@
+package models
+
+import "go.mongodb.org/mongo-driver/bson/primitive"
+
+type CaseShare struct {
+	Id          primitive.ObjectID `json:"id" bson:"_id,omitempty"`
+	TaskId      string             `json:"task_id" bson:"task_id"`
+	OwnerId     string             `json:"owner_id" bson:"owner_id"`
+	OwnerEmail  string             `json:"owner_email" bson:"owner_email"`
+	Email       string             `json:"email" bson:"email"`
+	Token       string             `json:"token" bson:"token"`
+	Permissions []string           `json:"permissions" bson:"permissions"` // e.g. ["view"]
+	IsActive    bool               `json:"is_active" bson:"is_active"`
+	ExpiresAt   int64              `json:"expires_at" bson:"expires_at"`
+	CreatedAt   int64              `json:"created_at" bson:"created_at"`
+	OTPCode     string             `json:"-" bson:"otp_code,omitempty"`
+	OTPExpiry   int64              `json:"-" bson:"otp_expiry,omitempty"`
+	OTPAttempts int                `json:"-" bson:"otp_attempts,omitempty"`
+}
+
+// Input/Output types for repository operations
+
+type CreateCaseShareInput struct {
+	Share CaseShare `json:"share"`
+}
+type CreateCaseShareOutput struct {
+	Share *CaseShare `json:"share"`
+}
+
+type GetCaseShareByTokenInput struct {
+	Token string `json:"token"`
+}
+type GetCaseShareByTokenOutput struct {
+	Share *CaseShare `json:"share"`
+}
+
+type GetCaseSharesForTaskInput struct {
+	TaskId  string `json:"task_id"`
+	OwnerId string `json:"owner_id"`
+}
+type GetCaseSharesForTaskOutput struct {
+	Shares []CaseShare `json:"shares"`
+}
+
+type DeleteCaseShareInput struct {
+	ShareId string `json:"share_id"`
+	OwnerId string `json:"owner_id"`
+}
+type DeleteCaseShareOutput struct{}

--- a/pkg/models/case_share.go
+++ b/pkg/models/case_share.go
@@ -48,3 +48,10 @@ type DeleteCaseShareInput struct {
 	UserId  string `json:"user_id"`
 }
 type DeleteCaseShareOutput struct{}
+
+type UpdateCaseShareOTPInput struct {
+	Token   string `json:"token"`
+	OTPCode string `json:"otp_code"`
+	Expiry  int64  `json:"otp_expiry"`
+}
+type UpdateCaseShareOTPOutput struct{}

--- a/pkg/models/workflow.go
+++ b/pkg/models/workflow.go
@@ -30,6 +30,7 @@ type Workflow struct {
 	Id           primitive.ObjectID `json:"id" bson:"_id,omitempty"`
 	Name         string             `json:"name" bson:"name,omitempty"`
 	Description  string             `json:"description" bson:"description,omitempty"`
+	Enabled      bool               `json:"enabled" bson:"enabled"`
 	Nodes        []WorkflowNode     `json:"nodes" bson:"nodes"`
 	Edges        []WorkflowEdge     `json:"edges" bson:"edges"`
 	UserId       string             `json:"user_id" bson:"user_id,omitempty"`


### PR DESCRIPTION
## Description

This PR introduces the **CaseShare** domain model along with clear input/output types to support secure task sharing workflows. It lays the groundwork for sharing cases externally via tokens, permissions, expiration, and OTP-based access, without overloading existing task or user models.

By formalizing CaseShare as a first‑class model, the codebase gains:
- A clean, explicit contract for repository and API interactions around sharing
- Better separation of concerns between tasks and access control
- A scalable foundation for future features like external collaboration and auditability

Additionally, the small structural cleanups and the new `Enabled` flag on workflows improve data clarity and control without changing existing behavior.

Overall, this change improves extensibility, readability, and long‑term maintainability while enabling an important product capability.