### PR TITLE
add redaction

### DIFF
--- a/pkg/models/task.go
+++ b/pkg/models/task.go
@@ -99,6 +99,15 @@ type ExportFile struct {
 	ThumbnailFile     string `json:"thumbnailFile" bson:"thumbnailFile"`
 	ThumbnailProvider string `json:"thumbnailProvider" bson:"thumbnailProvider"`
 	ThumbnailUrl      string `json:"thumbnail_url,omitempty" bson:"thumbnail_url,omitempty"`
+	// Redaction variant: when present, the API has discovered a redacted
+	// version of this media in the media collection. RedactionFile /
+	// RedactionProvider mirror the corresponding fields on the Media doc,
+	// and RedactionUrl carries the signed URL for client playback. These
+	// are populated by the API at fetch time and are not persisted on the
+	// task document.
+	RedactionFile     string `json:"redaction_file,omitempty" bson:"-"`
+	RedactionProvider string `json:"redaction_provider,omitempty" bson:"-"`
+	RedactionUrl      string `json:"redaction_url,omitempty" bson:"-"`
 }
 
 type MediaWrapper struct {


### PR DESCRIPTION
## Description

### Motivation

We need a way to expose redacted versions of media to clients without changing the persisted task schema or duplicating data. Today, even when a redacted asset exists, the API has no structured way to surface it alongside the original export.

### Why this improves the project

This change adds explicit redaction fields to `ExportFile` that are populated dynamically at fetch time. It allows the API to return signed URLs for redacted media when available, while keeping storage and persistence unchanged. This cleanly enables redaction support, improves client flexibility, and preserves backward compatibility with existing data and consumers.