### PR TITLE
Add FaceRedactionStatus and update FaceRedaction model

### DIFF
--- a/pkg/api/analysis.go
+++ b/pkg/api/analysis.go
@@ -174,6 +174,22 @@ type FaceRedactionMessage struct {
 	Data   map[string]interface{} `json:"data,omitempty"`
 }
 
+// FaceRedactionStatusEvent is the structured payload published by
+// hub-pipeline-redaction onto the analysis queue (under
+// event.Data["redaction"]) to drive lifecycle transitions of the
+// face-redaction job recorded on the Analysis document. The receiving
+// service (hub-pipeline-analysis) owns the corresponding MongoDB writes.
+//
+// FileName carries the source media filename and is used by the analysis
+// service to locate the matching Media document when the job completes.
+type FaceRedactionStatusEvent struct {
+	AnalysisId     string                     `json:"analysisId"`
+	OrganisationId string                     `json:"organisationId"`
+	FileName       string                     `json:"fileName,omitempty"`
+	Status         models.FaceRedactionStatus `json:"status"`
+	StatusError    string                     `json:"statusError,omitempty"`
+}
+
 // GetAnalysis
 // @Router /analysis [get]
 type GetAnalysisRequest struct {

--- a/pkg/models/analysis.go
+++ b/pkg/models/analysis.go
@@ -166,11 +166,39 @@ type FaceRedaction struct {
 	Id     primitive.ObjectID   `json:"id" bson:"_id,omitempty"`
 	Tracks []FaceRedactionTrack `json:"tracks" bson:"tracks"`
 	// Status reflects the lifecycle of the redaction job driven by the
-	// hub-pipeline-redaction worker: "" (unsubmitted), "queued",
-	// "processing", "completed", "failed".
-	Status string `json:"status,omitempty" bson:"status,omitempty"`
+	// hub-pipeline-redaction worker. See FaceRedactionStatus for the
+	// allowed values.
+	Status FaceRedactionStatus `json:"status,omitempty" bson:"status,omitempty"`
 	// StatusError carries the failure reason when Status == "failed".
 	StatusError string `json:"statusError,omitempty" bson:"statusError,omitempty"`
 	// UpdatedAt is the unix timestamp of the last status transition.
 	UpdatedAt int64 `json:"updatedAt,omitempty" bson:"updatedAt,omitempty"`
 }
+
+// FaceRedactionStatus enumerates the lifecycle states of a face-redaction
+// job persisted on FaceRedaction.Status.
+//
+//   - "" (unsubmitted): redaction tracks saved but no job has been queued.
+//   - "queued":       hub-api accepted the submit request and enqueued the job.
+//   - "processing":   the hub-pipeline-redaction worker is rendering.
+//   - "completed":    the redacted artifact is available on the Media doc.
+//   - "failed":       the worker aborted; see FaceRedaction.StatusError.
+type FaceRedactionStatus string
+
+const (
+	FaceRedactionStatusUnsubmitted FaceRedactionStatus = ""
+	FaceRedactionStatusQueued      FaceRedactionStatus = "queued"
+	FaceRedactionStatusProcessing  FaceRedactionStatus = "processing"
+	FaceRedactionStatusCompleted   FaceRedactionStatus = "completed"
+	FaceRedactionStatusFailed      FaceRedactionStatus = "failed"
+)
+
+// RedactionMode describes the visual technique applied by the
+// hub-pipeline-redaction worker over each track region.
+type RedactionMode string
+
+const (
+	RedactionModeBlur     RedactionMode = "blur"
+	RedactionModePixelate RedactionMode = "pixelate"
+	RedactionModeBlack    RedactionMode = "black"
+)


### PR DESCRIPTION
## Description

## Motivation

Face redaction job state was previously represented as a free-form string and updated implicitly, making lifecycle handling brittle and error‑prone across services. There was also no strongly typed contract for status events emitted by the redaction pipeline, which made coordination between `hub-pipeline-redaction` and `hub-pipeline-analysis` harder to reason about and validate.

## What this improves

This change introduces a typed `FaceRedactionStatus` enum and a structured `FaceRedactionStatusEvent` payload. Together, they:

- Make the face‑redaction lifecycle explicit, documented, and type‑safe.
- Provide a clear, stable contract for propagating job state transitions via the analysis queue.
- Reduce ambiguity and invalid states caused by ad‑hoc string values.
- Simplify downstream logic and MongoDB updates by standardising how status and errors are communicated.

Overall, this improves reliability, readability, and cross‑service coordination of face redaction workflows.