### PR TITLE
Enhance FaceRedactionStatusEvent and ExportFile 

### DIFF
--- a/pkg/api/analysis.go
+++ b/pkg/api/analysis.go
@@ -182,12 +182,18 @@ type FaceRedactionMessage struct {
 //
 // FileName carries the source media filename and is used by the analysis
 // service to locate the matching Media document when the job completes.
+// RedactionFile / RedactionProvider carry the storage location of the
+// rendered artefact and are populated on the terminal Completed event so
+// the analysis service can persist them onto both the Media and any
+// referencing Task / Case documents.
 type FaceRedactionStatusEvent struct {
-	AnalysisId     string                     `json:"analysisId"`
-	OrganisationId string                     `json:"organisationId"`
-	FileName       string                     `json:"fileName,omitempty"`
-	Status         models.FaceRedactionStatus `json:"status"`
-	StatusError    string                     `json:"statusError,omitempty"`
+	AnalysisId        string                     `json:"analysisId"`
+	OrganisationId    string                     `json:"organisationId"`
+	FileName          string                     `json:"fileName,omitempty"`
+	Status            models.FaceRedactionStatus `json:"status"`
+	StatusError       string                     `json:"statusError,omitempty"`
+	RedactionFile     string                     `json:"redactionFile,omitempty"`
+	RedactionProvider string                     `json:"redactionProvider,omitempty"`
 }
 
 // GetAnalysis

--- a/pkg/models/task.go
+++ b/pkg/models/task.go
@@ -99,14 +99,14 @@ type ExportFile struct {
 	ThumbnailFile     string `json:"thumbnailFile" bson:"thumbnailFile"`
 	ThumbnailProvider string `json:"thumbnailProvider" bson:"thumbnailProvider"`
 	ThumbnailUrl      string `json:"thumbnail_url,omitempty" bson:"thumbnail_url,omitempty"`
-	// Redaction variant: when present, the API has discovered a redacted
-	// version of this media in the media collection. RedactionFile /
-	// RedactionProvider mirror the corresponding fields on the Media doc,
-	// and RedactionUrl carries the signed URL for client playback. These
-	// are populated by the API at fetch time and are not persisted on the
-	// task document.
-	RedactionFile     string `json:"redaction_file,omitempty" bson:"-"`
-	RedactionProvider string `json:"redaction_provider,omitempty" bson:"-"`
+	// Redaction variant: persisted onto the task document by
+	// hub-pipeline-analysis when the corresponding redaction job completes.
+	// RedactionFile / RedactionProvider mirror the matching fields on the
+	// Media doc so downstream consumers (export, frontend) can resolve the
+	// redacted artefact without a join. RedactionUrl is signed by the API at
+	// fetch time and is therefore not persisted.
+	RedactionFile     string `json:"redaction_file,omitempty" bson:"redaction_file,omitempty"`
+	RedactionProvider string `json:"redaction_provider,omitempty" bson:"redaction_provider,omitempty"`
 	RedactionUrl      string `json:"redaction_url,omitempty" bson:"-"`
 }
 


### PR DESCRIPTION
## Description

**Motivation & Impact**

Face redaction currently completes without reliably propagating where the rendered redacted artefact is stored. As a result, downstream consumers (API, export, frontend) must infer or re-discover this data, adding coupling, extra queries, and failure modes.

This change makes redaction outputs first-class data:

- The face redaction pipeline now emits `RedactionFile` and `RedactionProvider` on the terminal status event, ensuring the analysis service can persist the artefact location at completion time.
- `ExportFile` is updated to persist these fields directly on the task document, removing the need for runtime joins against Media to resolve redacted variants.

**Why this improves the project**

- Makes redaction completion deterministic and self-contained.
- Simplifies downstream consumers by providing direct access to redacted artefacts.
- Reduces runtime lookups and tight coupling between API, Media, and Task documents.
- Aligns data ownership with the pipeline that produces it, improving long-term maintainability.