### PR TITLE
refactor/admin-api-responses

### DIFF
--- a/pkg/api/admin.go
+++ b/pkg/api/admin.go
@@ -1,0 +1,290 @@
+package api
+
+// AdminStatus represents specific status codes for admin dashboard operations.
+type AdminStatus string
+
+const (
+	AdminStatsSuccess AdminStatus = "admin_stats_success"
+	AdminStatsFailed  AdminStatus = "admin_stats_failed"
+)
+
+// String returns the string representation of the admin status.
+func (s AdminStatus) String() string {
+	return string(s)
+}
+
+// Translate returns the translated string representation of the admin status
+// in the specified language.
+func (s AdminStatus) Translate(lang string) string {
+	translations := map[string]map[AdminStatus]string{
+		"en": {
+			AdminStatsSuccess: "Admin stats retrieved successfully",
+			AdminStatsFailed:  "Admin stats retrieval failed",
+		},
+	}
+
+	if langTranslations, exists := translations[lang]; exists {
+		if translation, exists := langTranslations[s]; exists {
+			return translation
+		}
+	}
+
+	if enTranslations, exists := translations["en"]; exists {
+		if translation, exists := enTranslations[s]; exists {
+			return translation
+		}
+	}
+
+	return s.String()
+}
+
+// ----------------------------------------------------------------------------
+// Admin response wrappers
+//
+// These envelopes are shared by the hub-api admin endpoints (versioned under
+// /admin/v20260101). They embed the canonical SuccessResponse / ErrorResponse
+// envelope so the wire format matches device / task / alert endpoints.
+//
+// Entity-typed payload fields use `any` for now because several of the
+// underlying entity types (DeviceShort, UserSubscription, SiteShort,
+// OrganisationType, OrganisationRole, SubscriptionPlan, …) still live in
+// hub-api/api/models. Once those entities migrate to models/pkg/models the
+// `any` fields can be tightened to their concrete types without changing the
+// wire format.
+// ----------------------------------------------------------------------------
+
+// ---------- Stats ----------
+
+// AdminRecentSubscription is a lightweight projection of a user subscription
+// enriched with the owning user's display name (used by the admin dashboard).
+//
+// The fields use `any` for values whose representation differs across the
+// underlying entities (UserSubscription vs SubscriptionPlan). Once those
+// entities migrate to models/pkg/models the types can be tightened.
+type AdminRecentSubscription struct {
+	Id           any    `json:"id"`
+	Name         string `json:"name"`
+	UserId       string `json:"user_id"`
+	StripePlan   string `json:"stripe_plan"`
+	StripeActive any    `json:"stripe_active"`
+	Quantity     any    `json:"quantity"`
+	EndsAt       any    `json:"ends_at"`
+	CreatedAt    any    `json:"created_at"`
+	Username     string `json:"username"`
+}
+
+type GetAdminStatsResponse struct {
+	DeviceCount         int64                     `json:"device_count"`
+	SubscriptionCount   int64                     `json:"subscription_count"`
+	RecordingCount      int64                     `json:"recording_count"`
+	UserCount           int64                     `json:"user_count"`
+	OrganisationCount   int64                     `json:"organisation_count"`
+	RecentUsers         any                       `json:"recent_users"`
+	RecentOrganisations any                       `json:"recent_organisations"`
+	RecentSubscriptions []AdminRecentSubscription `json:"recent_subscriptions"`
+}
+
+type GetAdminStatsSuccessResponse struct {
+	SuccessResponse
+	Data GetAdminStatsResponse `json:"data,omitempty"`
+}
+
+type GetAdminStatsErrorResponse struct {
+	ErrorResponse
+}
+
+// ---------- Organisations (admin variant) ----------
+
+type GetAdminOrganisationsMeta struct {
+	TotalOrganisationCount int64 `json:"total_organisation_count"`
+	OrganisationCount      int64 `json:"organisation_count"`
+	TotalPages             int   `json:"total_pages"`
+	OrganisationTypes      any   `json:"organisation_types"`
+	OrganisationRoles      any   `json:"organisation_roles"`
+}
+
+type GetAdminOrganisationsResponse struct {
+	Organisations any                       `json:"organisations"`
+	Meta          GetAdminOrganisationsMeta `json:"meta"`
+}
+
+type GetAdminOrganisationsSuccessResponse struct {
+	SuccessResponse
+	Data GetAdminOrganisationsResponse `json:"data,omitempty"`
+}
+
+type GetAdminOrganisationsErrorResponse struct {
+	ErrorResponse
+}
+
+type CreateAdminOrganisationResponse struct {
+	Organisation any `json:"organisation"`
+}
+
+type CreateAdminOrganisationSuccessResponse struct {
+	SuccessResponse
+	Data CreateAdminOrganisationResponse `json:"data,omitempty"`
+}
+
+type CreateAdminOrganisationErrorResponse struct {
+	ErrorResponse
+}
+
+// ---------- Users (admin variants) ----------
+
+type CreateAdminUserResponse struct {
+	User any `json:"user"`
+}
+
+type CreateAdminUserSuccessResponse struct {
+	SuccessResponse
+	Data CreateAdminUserResponse `json:"data,omitempty"`
+}
+
+type CreateAdminUserErrorResponse struct {
+	ErrorResponse
+}
+
+type GetAdminUsersMeta struct {
+	TotalUserCount int64 `json:"total_user_count"`
+	UserCount      int64 `json:"user_count"`
+	TotalPages     int   `json:"total_pages"`
+}
+
+type GetAdminUsersResponse struct {
+	Users any               `json:"users"`
+	Meta  GetAdminUsersMeta `json:"meta"`
+}
+
+type GetAdminUsersSuccessResponse struct {
+	SuccessResponse
+	Data GetAdminUsersResponse `json:"data,omitempty"`
+}
+
+type GetAdminUsersErrorResponse struct {
+	ErrorResponse
+}
+
+type GetAdminUserProfileResponse struct {
+	User any `json:"user"`
+}
+
+type GetAdminUserProfileSuccessResponse struct {
+	SuccessResponse
+	Data GetAdminUserProfileResponse `json:"data,omitempty"`
+}
+
+type GetAdminUserProfileErrorResponse struct {
+	ErrorResponse
+}
+
+type GenerateAdminUserKeyResponse struct {
+	PublicKey  string `json:"public_key"`
+	PrivateKey string `json:"private_key,omitempty"`
+}
+
+type GenerateAdminUserKeySuccessResponse struct {
+	SuccessResponse
+	Data GenerateAdminUserKeyResponse `json:"data,omitempty"`
+}
+
+type GenerateAdminUserKeyErrorResponse struct {
+	ErrorResponse
+}
+
+type UpdateAdminUserResponse struct {
+	User any `json:"user"`
+}
+
+type UpdateAdminUserSuccessResponse struct {
+	SuccessResponse
+	Data UpdateAdminUserResponse `json:"data,omitempty"`
+}
+
+type UpdateAdminUserErrorResponse struct {
+	ErrorResponse
+}
+
+type UpdateAdminUserPasswordSuccessResponse struct {
+	SuccessResponse
+}
+
+type UpdateAdminUserPasswordErrorResponse struct {
+	ErrorResponse
+}
+
+// ---------- User devices (admin variants) ----------
+
+type GetAdminUserDevicesMeta struct {
+	TotalDeviceCount int `json:"total_device_count"`
+	DeviceCount      int `json:"device_count"`
+	TotalPages       int `json:"total_pages"`
+}
+
+type GetAdminUserDevicesInformationResponse struct {
+	Devices any                     `json:"devices"`
+	Meta    GetAdminUserDevicesMeta `json:"meta"`
+}
+
+type GetAdminUserDevicesInformationSuccessResponse struct {
+	SuccessResponse
+	Data GetAdminUserDevicesInformationResponse `json:"data,omitempty"`
+}
+
+type GetAdminUserDevicesInformationErrorResponse struct {
+	ErrorResponse
+}
+
+type GetAdminUserDevicesResponse struct {
+	Devices any `json:"devices"`
+}
+
+type GetAdminUserDevicesSuccessResponse struct {
+	SuccessResponse
+	Data GetAdminUserDevicesResponse `json:"data,omitempty"`
+}
+
+type GetAdminUserDevicesErrorResponse struct {
+	ErrorResponse
+}
+
+// ---------- Subscriptions (admin variants) ----------
+
+type GetAdminSubscriptionSettingsResponse struct {
+	Settings any `json:"settings"`
+}
+
+type GetAdminSubscriptionSettingsSuccessResponse struct {
+	SuccessResponse
+	Data GetAdminSubscriptionSettingsResponse `json:"data,omitempty"`
+}
+
+type GetAdminSubscriptionSettingsErrorResponse struct {
+	ErrorResponse
+}
+
+type GetAdminUserSubscriptionResponse struct {
+	Subscription any `json:"subscription"`
+}
+
+type GetAdminUserSubscriptionSuccessResponse struct {
+	SuccessResponse
+	Data GetAdminUserSubscriptionResponse `json:"data,omitempty"`
+}
+
+type GetAdminUserSubscriptionErrorResponse struct {
+	ErrorResponse
+}
+
+type UpdateAdminUserSubscriptionResponse struct {
+	Subscription any `json:"subscription"`
+}
+
+type UpdateAdminUserSubscriptionSuccessResponse struct {
+	SuccessResponse
+	Data UpdateAdminUserSubscriptionResponse `json:"data,omitempty"`
+}
+
+type UpdateAdminUserSubscriptionErrorResponse struct {
+	ErrorResponse
+}

--- a/pkg/api/admin.go
+++ b/pkg/api/admin.go
@@ -248,6 +248,41 @@ type GetAdminUserDevicesErrorResponse struct {
 	ErrorResponse
 }
 
+// ---------- Devices (admin variants - all devices) ----------
+
+type GetAdminDevicesMeta struct {
+	TotalDeviceCount int `json:"total_device_count"`
+	DeviceCount      int `json:"device_count"`
+	TotalPages       int `json:"total_pages"`
+}
+
+type GetAdminDevicesResponse struct {
+	Devices any                 `json:"devices"`
+	Meta    GetAdminDevicesMeta `json:"meta"`
+}
+
+type GetAdminDevicesSuccessResponse struct {
+	SuccessResponse
+	Data GetAdminDevicesResponse `json:"data,omitempty"`
+}
+
+type GetAdminDevicesErrorResponse struct {
+	ErrorResponse
+}
+
+type GetAdminDeviceResponse struct {
+	Device any `json:"device"`
+}
+
+type GetAdminDeviceSuccessResponse struct {
+	SuccessResponse
+	Data GetAdminDeviceResponse `json:"data,omitempty"`
+}
+
+type GetAdminDeviceErrorResponse struct {
+	ErrorResponse
+}
+
 // ---------- Subscriptions (admin variants) ----------
 
 type GetAdminSubscriptionSettingsResponse struct {

--- a/pkg/api/admin_test.go
+++ b/pkg/api/admin_test.go
@@ -1,0 +1,32 @@
+package api
+
+import "testing"
+
+func TestAdminStatus_String(t *testing.T) {
+	if got := AdminStatsSuccess.String(); got != "admin_stats_success" {
+		t.Errorf("String() = %q, want %q", got, "admin_stats_success")
+	}
+}
+
+func TestAdminStatus_Translate(t *testing.T) {
+	tests := []struct {
+		name   string
+		status AdminStatus
+		lang   string
+		want   string
+	}{
+		{"english stats success", AdminStatsSuccess, "en", "Admin stats retrieved successfully"},
+		{"english stats failed", AdminStatsFailed, "en", "Admin stats retrieval failed"},
+		{"unknown lang falls back to english", AdminStatsSuccess, "xx", "Admin stats retrieved successfully"},
+		{"unknown status returns raw value", AdminStatus("admin_unknown"), "en", "admin_unknown"},
+		{"unknown lang and status returns raw value", AdminStatus("admin_unknown"), "xx", "admin_unknown"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.status.Translate(tc.lang); got != tc.want {
+				t.Errorf("Translate(%q) = %q, want %q", tc.lang, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/api/organisation.go
+++ b/pkg/api/organisation.go
@@ -1,0 +1,63 @@
+package api
+
+// OrganisationStatus represents specific status codes for organisation operations.
+type OrganisationStatus string
+
+const (
+	OrganisationBindingFailed  OrganisationStatus = "organisation_binding_failed"
+	OrganisationMissingInfo    OrganisationStatus = "organisation_missing_info"
+	OrganisationNameExists     OrganisationStatus = "organisation_name_exists"
+	OrganisationFound          OrganisationStatus = "organisation_found"
+	OrganisationNotFound       OrganisationStatus = "organisation_not_found"
+	OrganisationGetAllSuccess  OrganisationStatus = "organisation_get_all_success"
+	OrganisationGetAllFailed   OrganisationStatus = "organisation_get_all_failed"
+	OrganisationCreateSuccess  OrganisationStatus = "organisation_create_success"
+	OrganisationCreateFailed   OrganisationStatus = "organisation_create_failed"
+	OrganisationUpdateSuccess  OrganisationStatus = "organisation_update_success"
+	OrganisationUpdateFailed   OrganisationStatus = "organisation_update_failed"
+	OrganisationDeleteSuccess  OrganisationStatus = "organisation_delete_success"
+	OrganisationDeleteFailed   OrganisationStatus = "organisation_delete_failed"
+	OrganisationValidationFail OrganisationStatus = "organisation_validation_failed"
+)
+
+// String returns the string representation of the organisation status.
+func (s OrganisationStatus) String() string {
+	return string(s)
+}
+
+// Translate returns the translated string representation of the organisation
+// status in the specified language.
+func (s OrganisationStatus) Translate(lang string) string {
+	translations := map[string]map[OrganisationStatus]string{
+		"en": {
+			OrganisationBindingFailed:  "Organisation binding failed",
+			OrganisationMissingInfo:    "Organisation is missing required information",
+			OrganisationNameExists:     "Organisation name already exists",
+			OrganisationFound:          "Organisation found",
+			OrganisationNotFound:       "Organisation not found",
+			OrganisationGetAllSuccess:  "Organisations retrieved successfully",
+			OrganisationGetAllFailed:   "Failed to retrieve organisations",
+			OrganisationCreateSuccess:  "Organisation created successfully",
+			OrganisationCreateFailed:   "Failed to create organisation",
+			OrganisationUpdateSuccess:  "Organisation updated successfully",
+			OrganisationUpdateFailed:   "Failed to update organisation",
+			OrganisationDeleteSuccess:  "Organisation deleted successfully",
+			OrganisationDeleteFailed:   "Failed to delete organisation",
+			OrganisationValidationFail: "Organisation validation failed",
+		},
+	}
+
+	if langTranslations, exists := translations[lang]; exists {
+		if translation, exists := langTranslations[s]; exists {
+			return translation
+		}
+	}
+
+	if enTranslations, exists := translations["en"]; exists {
+		if translation, exists := enTranslations[s]; exists {
+			return translation
+		}
+	}
+
+	return s.String()
+}

--- a/pkg/api/organisation_test.go
+++ b/pkg/api/organisation_test.go
@@ -1,0 +1,44 @@
+package api
+
+import "testing"
+
+func TestOrganisationStatus_String(t *testing.T) {
+	if got := OrganisationFound.String(); got != "organisation_found" {
+		t.Errorf("String() = %q, want %q", got, "organisation_found")
+	}
+}
+
+func TestOrganisationStatus_Translate(t *testing.T) {
+	tests := []struct {
+		name   string
+		status OrganisationStatus
+		lang   string
+		want   string
+	}{
+		{"english binding failed", OrganisationBindingFailed, "en", "Organisation binding failed"},
+		{"english missing info", OrganisationMissingInfo, "en", "Organisation is missing required information"},
+		{"english name exists", OrganisationNameExists, "en", "Organisation name already exists"},
+		{"english found", OrganisationFound, "en", "Organisation found"},
+		{"english not found", OrganisationNotFound, "en", "Organisation not found"},
+		{"english get all success", OrganisationGetAllSuccess, "en", "Organisations retrieved successfully"},
+		{"english get all failed", OrganisationGetAllFailed, "en", "Failed to retrieve organisations"},
+		{"english create success", OrganisationCreateSuccess, "en", "Organisation created successfully"},
+		{"english create failed", OrganisationCreateFailed, "en", "Failed to create organisation"},
+		{"english update success", OrganisationUpdateSuccess, "en", "Organisation updated successfully"},
+		{"english update failed", OrganisationUpdateFailed, "en", "Failed to update organisation"},
+		{"english delete success", OrganisationDeleteSuccess, "en", "Organisation deleted successfully"},
+		{"english delete failed", OrganisationDeleteFailed, "en", "Failed to delete organisation"},
+		{"english validation fail", OrganisationValidationFail, "en", "Organisation validation failed"},
+		{"unknown lang falls back to english", OrganisationFound, "xx", "Organisation found"},
+		{"unknown status returns raw value", OrganisationStatus("organisation_unknown"), "en", "organisation_unknown"},
+		{"unknown lang and status returns raw value", OrganisationStatus("organisation_unknown"), "xx", "organisation_unknown"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.status.Translate(tc.lang); got != tc.want {
+				t.Errorf("Translate(%q) = %q, want %q", tc.lang, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/api/registration.go
+++ b/pkg/api/registration.go
@@ -1,0 +1,66 @@
+package api
+
+// RegistrationStatus represents specific status codes for user registration
+// performed by an admin (POST /admin/user).
+type RegistrationStatus string
+
+const (
+	RegistrationBindingFailed      RegistrationStatus = "registration_binding_failed"
+	RegistrationMissingInfo        RegistrationStatus = "registration_missing_info"
+	RegistrationPasswordsNoMatch   RegistrationStatus = "registration_passwords_no_match"
+	RegistrationPasswordTooWeak    RegistrationStatus = "registration_password_too_weak"
+	RegistrationUsernameExists     RegistrationStatus = "registration_username_exists"
+	RegistrationEmailExists        RegistrationStatus = "registration_email_exists"
+	RegistrationCreateUserFailed   RegistrationStatus = "registration_create_user_failed"
+	RegistrationCreateOrgFailed    RegistrationStatus = "registration_create_organisation_failed"
+	RegistrationHashPasswordFailed RegistrationStatus = "registration_hash_password_failed"
+	RegistrationSuccess            RegistrationStatus = "registration_success"
+	RegistrationGenerateKeySuccess RegistrationStatus = "registration_generate_key_success"
+	RegistrationGenerateKeyFailed  RegistrationStatus = "registration_generate_key_failed"
+	RegistrationUpdatePasswordOK   RegistrationStatus = "registration_update_password_success"
+	RegistrationUpdatePasswordFail RegistrationStatus = "registration_update_password_failed"
+	RegistrationUserIdRequired     RegistrationStatus = "registration_user_id_required"
+)
+
+// String returns the string representation of the registration status.
+func (s RegistrationStatus) String() string {
+	return string(s)
+}
+
+// Translate returns the translated string representation of the registration
+// status in the specified language.
+func (s RegistrationStatus) Translate(lang string) string {
+	translations := map[string]map[RegistrationStatus]string{
+		"en": {
+			RegistrationBindingFailed:      "Registration binding failed",
+			RegistrationMissingInfo:        "Registration is missing required information",
+			RegistrationPasswordsNoMatch:   "Passwords do not match",
+			RegistrationPasswordTooWeak:    "Password is too weak",
+			RegistrationUsernameExists:     "Username already exists",
+			RegistrationEmailExists:        "Email already exists",
+			RegistrationCreateUserFailed:   "Failed to create user",
+			RegistrationCreateOrgFailed:    "Failed to create organisation for user",
+			RegistrationHashPasswordFailed: "Failed to hash password",
+			RegistrationSuccess:            "Registration successful",
+			RegistrationGenerateKeySuccess: "User key generated successfully",
+			RegistrationGenerateKeyFailed:  "Failed to generate user key",
+			RegistrationUpdatePasswordOK:   "Password updated successfully",
+			RegistrationUpdatePasswordFail: "Failed to update password",
+			RegistrationUserIdRequired:     "User ID is required",
+		},
+	}
+
+	if langTranslations, exists := translations[lang]; exists {
+		if translation, exists := langTranslations[s]; exists {
+			return translation
+		}
+	}
+
+	if enTranslations, exists := translations["en"]; exists {
+		if translation, exists := enTranslations[s]; exists {
+			return translation
+		}
+	}
+
+	return s.String()
+}

--- a/pkg/api/registration_test.go
+++ b/pkg/api/registration_test.go
@@ -1,0 +1,46 @@
+package api
+package api
+
+import "testing"
+
+func TestRegistrationStatus_String(t *testing.T) {
+	if got := RegistrationSuccess.String(); got != "registration_success" {
+		t.Errorf("String() = %q, want %q", got, "registration_success")
+	}
+}
+
+func TestRegistrationStatus_Translate(t *testing.T) {
+	tests := []struct {
+		name   string
+		status RegistrationStatus
+		lang   string
+		want   string
+	}{
+		{"english known", RegistrationBindingFailed, "en", "Registration binding failed"},
+		{"english missing info", RegistrationMissingInfo, "en", "Registration is missing required information"},
+		{"english passwords no match", RegistrationPasswordsNoMatch, "en", "Passwords do not match"},
+		{"english password too weak", RegistrationPasswordTooWeak, "en", "Password is too weak"},
+		{"english username exists", RegistrationUsernameExists, "en", "Username already exists"},
+		{"english email exists", RegistrationEmailExists, "en", "Email already exists"},
+		{"english create user failed", RegistrationCreateUserFailed, "en", "Failed to create user"},
+		{"english create org failed", RegistrationCreateOrgFailed, "en", "Failed to create organisation for user"},
+		{"english hash password failed", RegistrationHashPasswordFailed, "en", "Failed to hash password"},
+		{"english success", RegistrationSuccess, "en", "Registration successful"},
+		{"english generate key success", RegistrationGenerateKeySuccess, "en", "User key generated successfully"},
+		{"english generate key failed", RegistrationGenerateKeyFailed, "en", "Failed to generate user key"},
+		{"english update password ok", RegistrationUpdatePasswordOK, "en", "Password updated successfully"},
+		{"english update password fail", RegistrationUpdatePasswordFail, "en", "Failed to update password"},
+		{"english user id required", RegistrationUserIdRequired, "en", "User ID is required"},
+		{"unknown lang falls back to english", RegistrationSuccess, "xx", "Registration successful"},
+		{"unknown status returns raw value", RegistrationStatus("registration_unknown"), "en", "registration_unknown"},
+		{"unknown lang and status returns raw value", RegistrationStatus("registration_unknown"), "xx", "registration_unknown"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.status.Translate(tc.lang); got != tc.want {
+				t.Errorf("Translate(%q) = %q, want %q", tc.lang, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/api/registration_test.go
+++ b/pkg/api/registration_test.go
@@ -1,5 +1,4 @@
 package api
-package api
 
 import "testing"
 

--- a/pkg/api/subscription.go
+++ b/pkg/api/subscription.go
@@ -1,0 +1,53 @@
+package api
+
+// SubscriptionStatus represents specific status codes for subscription operations.
+type SubscriptionStatus string
+
+const (
+	SubscriptionFound             SubscriptionStatus = "subscription_found"
+	SubscriptionNotFound          SubscriptionStatus = "subscription_not_found"
+	SubscriptionGetAllSuccess     SubscriptionStatus = "subscription_get_all_success"
+	SubscriptionGetAllFailed      SubscriptionStatus = "subscription_get_all_failed"
+	SubscriptionGetSettingsFailed SubscriptionStatus = "subscription_get_settings_failed"
+	SubscriptionGetUserFailed     SubscriptionStatus = "subscription_get_user_failed"
+	SubscriptionUpdateSuccess     SubscriptionStatus = "subscription_update_success"
+	SubscriptionUpdateFailed      SubscriptionStatus = "subscription_update_failed"
+	SubscriptionBindingFailed     SubscriptionStatus = "subscription_binding_failed"
+)
+
+// String returns the string representation of the subscription status.
+func (s SubscriptionStatus) String() string {
+	return string(s)
+}
+
+// Translate returns the translated string representation of the subscription
+// status in the specified language.
+func (s SubscriptionStatus) Translate(lang string) string {
+	translations := map[string]map[SubscriptionStatus]string{
+		"en": {
+			SubscriptionFound:             "Subscription found",
+			SubscriptionNotFound:          "Subscription not found",
+			SubscriptionGetAllSuccess:     "Subscriptions retrieved successfully",
+			SubscriptionGetAllFailed:      "Failed to retrieve subscriptions",
+			SubscriptionGetSettingsFailed: "Failed to retrieve subscription settings",
+			SubscriptionGetUserFailed:     "Failed to retrieve user subscription",
+			SubscriptionUpdateSuccess:     "Subscription updated successfully",
+			SubscriptionUpdateFailed:      "Failed to update subscription",
+			SubscriptionBindingFailed:     "Subscription binding failed",
+		},
+	}
+
+	if langTranslations, exists := translations[lang]; exists {
+		if translation, exists := langTranslations[s]; exists {
+			return translation
+		}
+	}
+
+	if enTranslations, exists := translations["en"]; exists {
+		if translation, exists := enTranslations[s]; exists {
+			return translation
+		}
+	}
+
+	return s.String()
+}

--- a/pkg/api/subscription_test.go
+++ b/pkg/api/subscription_test.go
@@ -1,0 +1,39 @@
+package api
+
+import "testing"
+
+func TestSubscriptionStatus_String(t *testing.T) {
+	if got := SubscriptionFound.String(); got != "subscription_found" {
+		t.Errorf("String() = %q, want %q", got, "subscription_found")
+	}
+}
+
+func TestSubscriptionStatus_Translate(t *testing.T) {
+	tests := []struct {
+		name   string
+		status SubscriptionStatus
+		lang   string
+		want   string
+	}{
+		{"english found", SubscriptionFound, "en", "Subscription found"},
+		{"english not found", SubscriptionNotFound, "en", "Subscription not found"},
+		{"english get all success", SubscriptionGetAllSuccess, "en", "Subscriptions retrieved successfully"},
+		{"english get all failed", SubscriptionGetAllFailed, "en", "Failed to retrieve subscriptions"},
+		{"english get settings failed", SubscriptionGetSettingsFailed, "en", "Failed to retrieve subscription settings"},
+		{"english get user failed", SubscriptionGetUserFailed, "en", "Failed to retrieve user subscription"},
+		{"english update success", SubscriptionUpdateSuccess, "en", "Subscription updated successfully"},
+		{"english update failed", SubscriptionUpdateFailed, "en", "Failed to update subscription"},
+		{"english binding failed", SubscriptionBindingFailed, "en", "Subscription binding failed"},
+		{"unknown lang falls back to english", SubscriptionFound, "xx", "Subscription found"},
+		{"unknown status returns raw value", SubscriptionStatus("subscription_unknown"), "en", "subscription_unknown"},
+		{"unknown lang and status returns raw value", SubscriptionStatus("subscription_unknown"), "xx", "subscription_unknown"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.status.Translate(tc.lang); got != tc.want {
+				t.Errorf("Translate(%q) = %q, want %q", tc.lang, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

**Motivation**

Admin endpoints had inconsistent and loosely defined response shapes and status handling, making the API harder to reason about, document, and evolve. Status codes were often implicit, messages were duplicated or ad‑hoc, and admin responses did not clearly align with the rest of the API.

**Why this improves the project**

This refactor introduces explicit, typed status enums and standardized response envelopes for all admin, organisation, registration, and subscription APIs. It makes admin responses predictable, self-describing, and consistent with existing SuccessResponse / ErrorResponse patterns. The added translation layer centralizes user-facing messages and prepares the API for localization without changing the wire format. Overall, this improves maintainability, reduces ambiguity for clients, and provides a clear foundation for future model and API evolution.