### PR TITLE
feature/add-download-feature-role

### DIFF
--- a/pkg/models/role.go
+++ b/pkg/models/role.go
@@ -42,8 +42,9 @@ type FeaturePermissions struct {
 	Devices      AccessLevel `json:"devices" bson:"devices"`             // 0=none, 1=read, 2=write, 3=admin
 	Sites        AccessLevel `json:"sites" bson:"sites"`                 // 0=none, 1=read, 2=write, 3=admin
 	Groups       AccessLevel `json:"groups" bson:"groups"`               // 0=none, 1=read, 2=write, 3=admin
-	Roles        AccessLevel `json:"roles" bson:"roles"`                 // 0=none, 1=read, 2=write, 3=admin
-	Settings     AccessLevel `json:"settings" bson:"settings"`           // 0=none, 1=read, 2=write, 3=admin
+	Roles              AccessLevel `json:"roles" bson:"roles"`                             // 0=none, 1=read, 2=write, 3=admin
+	Settings           AccessLevel `json:"settings" bson:"settings"`                       // 0=none, 1=read, 2=write, 3=admin
+	DownloadRecordings AccessLevel `json:"download_recordings" bson:"download_recordings"` // 0=none, 1=read, 2=write, 3=admin
 }
 
 type TimeWindow struct {


### PR DESCRIPTION
## Description

### Motivation & Impact

We need a dedicated permission to control who can download recordings without overloading existing roles like *Settings* or *Roles*. Until now, download access could only be granted implicitly via broader permissions, making access control coarse-grained and harder to reason about.

This change introduces an explicit `DownloadRecordings` permission at the role model level. It improves the project by:
- Enabling fine‑grained, intention‑revealing access control for downloading recordings.
- Reducing the security risk of granting excessive permissions just to enable downloads.
- Laying a clear foundation for future features and UI logic that depend on download-specific authorization.

Overall, this makes the permission model clearer, safer, and more extensible.