### PR TITLE
detections - add fps

### DIFF
--- a/pkg/models/pipeline.go
+++ b/pkg/models/pipeline.go
@@ -94,6 +94,9 @@ func (pe *PipelineEvent) GetMedia() (Media, error) {
 		media.Metadata = &MediaMetadata{}
 		media.Metadata.MotionPixels = 0
 		media.Metadata.FileSize = pe.Payload.FileSize
+		if fps, err := strconv.Atoi(pe.Payload.Metadata.FPS); err == nil {
+			media.Metadata.FPS = fps
+		}
 
 		return media, nil
 	}
@@ -177,6 +180,8 @@ type PipelineMetadata struct {
 	DeviceName string `json:"event-instancename,omitempty"`
 
 	RegionCoordinates string `json:"event-regioncoordinates,omitempty"`
+
+	FPS string `json:"fps,omitempty"`
 }
 
 // HandlerResult represents the result of message handling


### PR DESCRIPTION
## Description

**Motivation & Impact**

Detections currently miss frame rate information, which limits how media quality and pipeline performance can be evaluated downstream. FPS is a key signal for understanding capture conditions, troubleshooting issues, and enabling more accurate analytics.

This change adds FPS to pipeline metadata and propagates it into media metadata in a safe, backward-compatible way. By exposing FPS where detections are consumed, the project gains better observability and richer context without impacting existing flows.