### PR TITLE
Enhance WorkflowNode and WorkflowStage with detailed parameter valida…

### DIFF
--- a/pkg/models/workflow.go
+++ b/pkg/models/workflow.go
@@ -23,8 +23,10 @@ type WorkflowNode struct {
 	// by platform- and user-defined stages), not its Mongo Id. Always set:
 	// every node is an instance of a catalog stage, resolved at compile time.
 	StageRef string `json:"stageRef" bson:"stageRef"`
-	// Data holds optional per-instance parameters passed to the stage for this
-	// placement, layered over the stage's catalog defaults.
+	// Data holds optional per-instance parameter values for this placement, keyed
+	// by parameter name. They are validated against and defaulted from the
+	// referenced stage's declared Params (see WorkflowStage.Params), layered over
+	// the stage's catalog defaults.
 	Data map[string]interface{} `json:"data,omitempty" bson:"data,omitempty"`
 }
 
@@ -41,13 +43,19 @@ type WorkflowNode struct {
 type WorkflowEdge struct {
 	Id     string `json:"id" bson:"id"`
 	Source string `json:"source" bson:"source"`
-	// SourcePort optionally selects which of the source node's outputs this edge
-	// reads; Condition is evaluated against that output's result.
+	// SourcePort optionally selects which of the source stage's declared Outputs
+	// (see WorkflowStage.Outputs) this edge reads; Condition is evaluated against
+	// that output's result. Empty means the stage's single implicit default port.
 	SourcePort string `json:"sourcePort" bson:"sourcePort"`
 	Target     string `json:"target" bson:"target"`
+	// TargetPort optionally selects which of the target stage's declared Inputs
+	// (see WorkflowStage.Inputs) this edge feeds. Empty means the default port.
 	TargetPort string `json:"targetPort" bson:"targetPort"`
 	// Condition is the structured predicate evaluated against the source stage's
-	// result. Nil means the edge is an unconditional dependency.
+	// result. Nil means the edge is an unconditional dependency. The edge is the
+	// authoring source of truth for routing: this Condition is what compiles into
+	// the target stage's Needs[].Condition (see WorkflowStage.Needs), which is the
+	// derived runtime projection.
 	Condition *StageCondition `json:"condition,omitempty" bson:"condition,omitempty"`
 }
 

--- a/pkg/models/workflowstage.go
+++ b/pkg/models/workflowstage.go
@@ -2,26 +2,45 @@ package models
 
 import "go.mongodb.org/mongo-driver/bson/primitive"
 
-// Dispatch modes for a workflow stage. Dispatch is a closed string enum: a
-// stage's Dispatch field must hold one of these exact values (it is a string
-// rather than a boolean so further modes — e.g. scheduled or manual — can be
-// added without a schema change). An empty Dispatch defaults to DispatchAlways.
+// Dispatch is the closed enum of dispatch modes for a workflow stage. It is a
+// named string — not a boolean — so further modes (e.g. scheduled or manual)
+// can be added without a schema change, and named so the permitted values live
+// in the type rather than in a comment. An empty Dispatch defaults to
+// DispatchAlways.
 //
 //	always      — enqueued at workflow start, unconditionally.
 //	conditional — enqueued only when one of its upstream dependencies resolves
 //	              and that dependency's Condition matches the upstream result.
+type Dispatch string
+
 const (
-	DispatchAlways      = "always"
-	DispatchConditional = "conditional"
+	DispatchAlways      Dispatch = "always"
+	DispatchConditional Dispatch = "conditional"
+)
+
+// ConditionOp is the closed enum of comparison operators a StageCondition may
+// use. Named so the allowed operators are part of the type instead of a comment.
+type ConditionOp string
+
+const (
+	ConditionOpEq       ConditionOp = "eq"       // equal
+	ConditionOpNe       ConditionOp = "ne"       // not equal
+	ConditionOpContains ConditionOp = "contains" // field (array element / string substring) contains Value
+	ConditionOpIn       ConditionOp = "in"       // field value is one of Value (a list); inverse of contains
+	ConditionOpExists   ConditionOp = "exists"   // path present (Value ignored)
+	ConditionOpGt       ConditionOp = "gt"       // greater than (numeric)
+	ConditionOpGte      ConditionOp = "gte"      // greater than or equal (numeric)
+	ConditionOpLt       ConditionOp = "lt"       // less than (numeric)
+	ConditionOpLte      ConditionOp = "lte"      // less than or equal (numeric)
 )
 
 // StageCondition is a structured predicate evaluated against an upstream
 // operation's returned result. No free-form expressions are allowed: a
 // condition is a single (path, op, value) triple.
 type StageCondition struct {
-	Path  string `json:"path" bson:"path"`   // dot-path into the upstream op's result
-	Op    string `json:"op" bson:"op"`       // eq | ne | contains | exists | gt | lt
-	Value any    `json:"value" bson:"value"` // comparison operand (unused for "exists")
+	Path  string      `json:"path" bson:"path"`   // dot-path into the upstream op's result
+	Op    ConditionOp `json:"op" bson:"op"`       // see the ConditionOp consts
+	Value any         `json:"value" bson:"value"` // comparison operand (unused for ConditionOpExists)
 }
 
 // StageDependency is one upstream a conditional stage waits on, paired with the
@@ -50,6 +69,43 @@ type StageResources struct {
 	Limits   *StageResourceList `json:"limits,omitempty" bson:"limits,omitempty"`
 }
 
+// StageParamType is the closed enum of declared parameter types. It tells the
+// authoring UI how to render a parameter and lets a node's Data be validated
+// instead of being free-form.
+type StageParamType string
+
+const (
+	StageParamString  StageParamType = "string"
+	StageParamNumber  StageParamType = "number"
+	StageParamBoolean StageParamType = "boolean"
+	StageParamSelect  StageParamType = "select"
+)
+
+// StageParam declares one configurable parameter a stage accepts. The catalog
+// stage owns the declaration; a WorkflowNode supplies the per-instance value
+// under the same Name in its Data map (see WorkflowNode.Data). Declaring params
+// here is what gives Data a schema to validate against and default from.
+type StageParam struct {
+	Name     string         `json:"name" bson:"name"`
+	Label    string         `json:"label,omitempty" bson:"label,omitempty"`
+	Type     StageParamType `json:"type" bson:"type"`
+	Required bool           `json:"required,omitempty" bson:"required,omitempty"`
+	// Default is applied when a node supplies no value for this parameter.
+	Default any `json:"default,omitempty" bson:"default,omitempty"`
+	// Options enumerates the permitted values when Type is StageParamSelect.
+	Options []string `json:"options,omitempty" bson:"options,omitempty"`
+}
+
+// StagePort is a named connection point on a stage. Outputs are the results a
+// downstream edge can read (selected by WorkflowEdge.SourcePort, and the space a
+// StageCondition.Path indexes into); inputs are the slots an upstream edge feeds
+// (selected by WorkflowEdge.TargetPort). A stage that declares no ports exposes a
+// single implicit default port, so simple linear stages need none.
+type StagePort struct {
+	Name  string `json:"name" bson:"name"`
+	Label string `json:"label,omitempty" bson:"label,omitempty"`
+}
+
 // WorkflowStage is a reusable, keyed stage definition — a catalog entry. The
 // same stage can be referenced by many workflows: a workflow's canvas nodes
 // reference a stage by its Operation key (see WorkflowNode.StageRef) rather
@@ -63,14 +119,20 @@ type StageResources struct {
 //   - User-defined stages, stored in Mongo and managed through the catalog CRUD
 //     below. These have an Id.
 //
-// It carries two groups of fields:
+// It carries three groups of fields:
 //
 //   - Routing — how the orchestrator dispatches and resolves the stage
-//     (operation, dispatch, needs). Routing is compiled from the workflow's
-//     edges: each incoming edge becomes a Needs entry (its upstream operation
-//     plus that edge's optional condition), and Dispatch is conditional when
-//     there is at least one such dependency. Operation is unique and binds the
-//     stage's queue and resolution.
+//     (operation, dispatch, needs). Routing has a single owner: for a user
+//     workflow the graph's edges are authoritative and Dispatch/Needs is the
+//     compiled projection of them (each incoming edge becomes a Needs entry —
+//     its upstream operation plus that edge's optional condition — and Dispatch
+//     is conditional when there is at least one), so these fields are derived
+//     and must not be hand-edited on a shared entry; for a platform-defined
+//     stage the projection is authored chart-side and is global. Operation is
+//     unique and binds the stage's queue and resolution.
+//   - Contract — what the stage accepts and exposes (params, inputs, outputs).
+//     Params give WorkflowNode.Data a schema; Inputs/Outputs are the named
+//     ports workflow edges attach to.
 //   - Deployment — how the stage's workers are deployed (repository, tag,
 //     replicas, queue, resources, …). These describe the running service that
 //     consumes the stage's queue.
@@ -91,18 +153,31 @@ type WorkflowStage struct {
 	// resolution. It is the key that workflow nodes reference. Two stages may
 	// never share an operation.
 	Operation string `json:"operation" bson:"operation"`
-	// Dispatch is when the stage runs, as a closed string enum: DispatchAlways
-	// or DispatchConditional (see the Dispatch consts). It is a string, not a
-	// boolean, so new modes can be added later without a schema change. Empty
-	// defaults to DispatchAlways.
-	Dispatch string `json:"dispatch,omitempty" bson:"dispatch,omitempty"`
-	// Needs lists the upstream dependencies of a conditional stage — its fan-in,
-	// compiled one-to-one from the workflow's incoming edges. At least one entry
-	// is required when Dispatch is DispatchConditional; ignored otherwise. The
-	// runtime re-evaluates the stage whenever any listed upstream resolves, and
-	// the stage fires for the first dependency whose Condition matches that
-	// upstream's result (a nil Condition matches unconditionally).
+	// Dispatch is when the stage runs: DispatchAlways or DispatchConditional (the
+	// closed Dispatch enum). Empty defaults to DispatchAlways. For a user
+	// workflow it is derived from the graph's edges (conditional when the node has
+	// at least one incoming edge); see the Routing note above.
+	Dispatch Dispatch `json:"dispatch,omitempty" bson:"dispatch,omitempty"`
+	// Needs lists the upstream dependencies of a conditional stage — its fan-in.
+	// It is the compiled, runtime-authoritative projection of the workflow's
+	// incoming edges (one entry per edge), not an independently editable field. At
+	// least one entry is required when Dispatch is DispatchConditional; ignored
+	// otherwise. The runtime re-evaluates the stage whenever any listed upstream
+	// resolves, and the stage fires for the first dependency whose Condition
+	// matches that upstream's result (a nil Condition matches unconditionally).
 	Needs []StageDependency `json:"needs,omitempty" bson:"needs,omitempty"`
+
+	// --- Contract ---
+
+	// Params declares the configurable parameters this stage accepts. A node's
+	// Data is validated against and defaulted from these (see WorkflowNode.Data);
+	// empty means the stage takes no parameters.
+	Params []StageParam `json:"params,omitempty" bson:"params,omitempty"`
+	// Inputs and Outputs declare the stage's named ports — the connection points
+	// workflow edges attach to (WorkflowEdge.TargetPort / SourcePort). Empty means
+	// a single implicit default port.
+	Inputs  []StagePort `json:"inputs,omitempty" bson:"inputs,omitempty"`
+	Outputs []StagePort `json:"outputs,omitempty" bson:"outputs,omitempty"`
 
 	// --- Deployment ---
 


### PR DESCRIPTION
## Description

### Motivation & Impact

Workflow authoring and execution currently rely on loosely defined contracts: node `Data` is free‑form, stage dispatch modes and condition operators are plain strings, and edge routing semantics are implicit. This makes workflows harder to validate, reason about, and evolve safely—both for the backend and for authoring UIs.

This change introduces explicit, typed contracts across **WorkflowNode**, **WorkflowStage**, and **WorkflowEdge**:

- **Schema-backed parameters**: stages now declare accepted params, giving `WorkflowNode.Data` a clear schema for validation and defaulting instead of unstructured maps.
- **Explicit routing semantics**: dispatch modes and condition operators are closed enums, preventing invalid states and making behavior self‑documenting.
- **Named inputs/outputs**: stages can declare ports, making edge connections and condition evaluation explicit and unambiguous.
- **Clear ownership of routing data**: edges are the single source of truth; stage `Dispatch` and `Needs` are defined as derived, runtime projections.

Overall, this strengthens correctness, enables early validation, improves API clarity, and lays the groundwork for safer workflow evolution and richer authoring experiences.