### PR TITLE
feature/update-workflow-organisationid

### DIFF
--- a/pkg/models/workflow.go
+++ b/pkg/models/workflow.go
@@ -76,18 +76,18 @@ type WorkflowTrigger struct {
 // and the edges that route between them. Trigger says what activates it; the
 // nodes/edges say what runs.
 type Workflow struct {
-	Id           primitive.ObjectID `json:"id" bson:"_id,omitempty"`
-	Name         string             `json:"name" bson:"name,omitempty"`
-	Description  string             `json:"description" bson:"description,omitempty"`
-	Enabled      bool               `json:"enabled" bson:"enabled"`
-	Trigger      *WorkflowTrigger   `json:"trigger,omitempty" bson:"trigger,omitempty"`
-	Nodes        []WorkflowNode     `json:"nodes" bson:"nodes"`
-	Edges        []WorkflowEdge     `json:"edges" bson:"edges"`
-	UserId       string             `json:"user_id" bson:"user_id,omitempty"`
-	Username     string             `json:"username" bson:"username,omitempty"`
-	MasterUserId string             `json:"master_user_id" bson:"master_user_id,omitempty"`
-	CreatedAt    int64              `json:"created_at" bson:"created_at,omitempty"`
-	UpdatedAt    int64              `json:"updated_at" bson:"updated_at,omitempty"`
+	Id             primitive.ObjectID `json:"id" bson:"_id,omitempty"`
+	Name           string             `json:"name" bson:"name,omitempty"`
+	Description    string             `json:"description" bson:"description,omitempty"`
+	Enabled        bool               `json:"enabled" bson:"enabled"`
+	Trigger        *WorkflowTrigger   `json:"trigger,omitempty" bson:"trigger,omitempty"`
+	Nodes          []WorkflowNode     `json:"nodes" bson:"nodes"`
+	Edges          []WorkflowEdge     `json:"edges" bson:"edges"`
+	UserId         string             `json:"user_id" bson:"user_id,omitempty"`
+	Username       string             `json:"username" bson:"username,omitempty"`
+	OrganisationId string             `json:"organisation_id" bson:"organisation_id,omitempty"`
+	CreatedAt      int64              `json:"created_at" bson:"created_at,omitempty"`
+	UpdatedAt      int64              `json:"updated_at" bson:"updated_at,omitempty"`
 }
 
 // Input / Output types for repository operations


### PR DESCRIPTION
## Description

**Motivation & Impact**

Workflows were previously scoped only to individual users, which limits support for multi-tenant and organisation-based use cases. This makes it harder to properly isolate data, enforce permissions, and reason about ownership as the platform grows.

This change introduces an explicit `organisation_id` on the `Workflow` model and removes the legacy `master_user_id`. By making organisation ownership a first‑class concept, workflows can now be reliably associated with an organisation rather than implicitly inferred from users.

This improves the project by:
- Enabling proper organisation-level scoping and access control.
- Simplifying the data model by removing redundant/ambiguous ownership fields.
- Laying the groundwork for scalable, multi-organisation features and cleaner queries.

Overall, this aligns workflows with the platform’s organisational model and makes future development safer and more predictable.