### PR TITLE
Workflows   stages

### DIFF
--- a/pkg/api/analysis.go
+++ b/pkg/api/analysis.go
@@ -207,7 +207,10 @@ type SaveFaceRedactionErrorResponse struct {
 // "detections" collection, keyed by the recording. Exactly one of MediaKey (the
 // recording key, i.e. media.videoFile / analysis.key - not the media _id) or
 // AnalysisId (the analysis document _id) must identify the target recording.
-// Runs are upserted by (recording key, Source.RunId).
+// Runs are upserted by (recording key, Source.RunId). The same body is also the
+// payload a delegated-ingest workflow stage returns for the "detection" kind —
+// set task "pose" for a pose run — in which case the engine targets the run's
+// recording from the WorkflowRun envelope and MediaKey/AnalysisId are not used.
 // @Router /detections [post]
 type PostDetectionsRequest struct {
 	// MediaKey is the recording KEY the run belongs to - the stable string that

--- a/pkg/api/anpr.go
+++ b/pkg/api/anpr.go
@@ -1,0 +1,115 @@
+package api
+
+import "github.com/uug-ai/models/pkg/models"
+
+// PostANPR
+//
+// Wire format for an automatic-number-plate-recognition result. It is the typed
+// body an ANPR producer returns — either as the `payload` of a delegated-ingest
+// workflow stage (operation "anpr", routed through the shared ingest core) or,
+// in future, as the body of an HTTP ingest door. The server validates and
+// normalises it into a models.ANPRRun stored in the dedicated "anpr"
+// collection, keyed by the recording and upserted by (recording key,
+// Source.RunId).
+//
+// It deliberately does not reuse PostDetectionsRequest: a plate read is
+// recognised text with candidate reads and a jurisdiction, a different contract
+// from a bounding-box detection track.
+type PostANPRRequest struct {
+	// MediaKey is the recording KEY the run belongs to — the stable string
+	// stored as media.videoFile / analysis.key (NOT the media document _id).
+	// Provide this or AnalysisId (MediaKey wins when both are present). Only the
+	// HTTP door uses these; over the workflows queue the engine resolves the
+	// target from the run envelope.
+	MediaKey string `json:"mediaKey,omitempty"`
+	// AnalysisId targets the recording via its analysis document _id (an
+	// ObjectID hex), as an alternative to MediaKey.
+	AnalysisId string `json:"analysisId,omitempty"`
+	// SchemaVersion is the producer's payload schema (optional).
+	SchemaVersion string `json:"schemaVersion,omitempty"`
+	// Source identifies the producer; Source.RunId is the upsert key.
+	Source models.ANPRSource `json:"source"`
+	// CoordinateSpace is the space plate boxes are sent in: "pixel" or
+	// "normalized". Required only when a plate carries a box.
+	CoordinateSpace string `json:"coordinateSpace,omitempty"`
+	// Media gives the recording dimensions used to normalise pixel-space boxes.
+	// Required when CoordinateSpace is "pixel" and any plate carries a box.
+	Media ANPRMediaInput `json:"media,omitempty"`
+	// Plates are the recognised plates. An empty list is valid — it records that
+	// ANPR ran and found nothing.
+	Plates []ANPRPlateInput `json:"plates"`
+}
+
+// ANPRMediaInput is the recording descriptor used to normalise pixel boxes.
+type ANPRMediaInput struct {
+	Width  int     `json:"width,omitempty"`
+	Height int     `json:"height,omitempty"`
+	Fps    float64 `json:"fps,omitempty"`
+}
+
+// ANPRPlateInput is one recognised plate on the wire. The box is optional and
+// accepts both the preferred {x, y, w, h} (top-left + size) and the legacy
+// {x1, y1, x2, y2} forms; pointers let the server detect which form was sent
+// and distinguish "no geometry" from a zero coordinate.
+type ANPRPlateInput struct {
+	// Plate is the recognised registration; stored normalised for search.
+	Plate string `json:"plate"`
+	// Display is the optional human-readable rendering.
+	Display string `json:"display,omitempty"`
+	// Confidence is the read confidence; clamped to [0, 1] on ingest.
+	Confidence float64 `json:"confidence,omitempty"`
+	// Country is the ISO 3166-1 alpha-2 jurisdiction (optional).
+	Country string `json:"country,omitempty"`
+	// Region is the sub-jurisdiction (optional).
+	Region string `json:"region,omitempty"`
+	// Frame is the representative frame the read came from (optional).
+	Frame int64 `json:"frame,omitempty"`
+	// TimestampMs is the representative time in ms into the recording (optional).
+	TimestampMs int64 `json:"timestampMs,omitempty"`
+	// Box geometry — preferred {x, y, w, h}.
+	X *float64 `json:"x,omitempty"`
+	Y *float64 `json:"y,omitempty"`
+	W *float64 `json:"w,omitempty"`
+	H *float64 `json:"h,omitempty"`
+	// Box geometry — legacy {x1, y1, x2, y2}.
+	X1 *float64 `json:"x1,omitempty"`
+	Y1 *float64 `json:"y1,omitempty"`
+	X2 *float64 `json:"x2,omitempty"`
+	Y2 *float64 `json:"y2,omitempty"`
+	// Candidates are alternative reads ranked below Plate (optional).
+	Candidates []ANPRCandidateInput `json:"candidates,omitempty"`
+	// Meta carries producer-specific extras (e.g. vehicle attributes); capped on
+	// ingest.
+	Meta map[string]interface{} `json:"meta,omitempty"`
+}
+
+// ANPRCandidateInput is one alternative plate read on the wire.
+type ANPRCandidateInput struct {
+	Plate      string  `json:"plate"`
+	Confidence float64 `json:"confidence,omitempty"`
+}
+
+// PostANPRResponse echoes what was stored plus any plates rejected during
+// normalisation.
+type PostANPRResponse struct {
+	RunId        string          `json:"runId"`
+	PlatesStored int             `json:"platesStored"`
+	Rejected     []ANPRRejection `json:"rejected"`
+	Warnings     []string        `json:"warnings"`
+}
+
+// ANPRRejection identifies a single plate that failed validation/normalisation.
+type ANPRRejection struct {
+	Plate  string `json:"plate"`
+	Frame  int64  `json:"frame"`
+	Reason string `json:"reason"`
+}
+
+type PostANPRSuccessResponse struct {
+	SuccessResponse
+	Data PostANPRResponse `json:"data"`
+}
+
+type PostANPRErrorResponse struct {
+	ErrorResponse
+}

--- a/pkg/ingest/anpr.go
+++ b/pkg/ingest/anpr.go
@@ -1,0 +1,409 @@
+package ingest
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/uug-ai/models/pkg/api"
+	"github.com/uug-ai/models/pkg/models"
+)
+
+// Validation and normalisation limits for the anpr kind. The geometry limits
+// (boundsTolerance, clampUnit, withinFrame) and the envelope caps (maxNameLen,
+// maxVersionLen, maxRunIdLen, maxMetaBytes) are shared with the detection kind —
+// they are generic, not redaction-specific.
+const (
+	maxPlatesPerRun       = 1000
+	maxPlateLen           = 32
+	maxCandidatesPerPlate = 16
+)
+
+// Per-plate rejection reasons surfaced in the report warnings.
+const (
+	reasonPlateMissingText    = "plate_missing_text"
+	reasonPlateTooLong        = "plate_text_too_long"
+	reasonPlateMissingGeom    = "plate_missing_geometry"
+	reasonPlateNonPositiveDim = "plate_non_positive_dimensions"
+	reasonPlateMissingScale   = "plate_missing_media_scale"
+	reasonPlateBoxOutOfFrame  = "plate_box_out_of_frame"
+)
+
+// ErrANPRValidation wraps an ANPR request-envelope validation failure (missing
+// runId, oversize plate list, missing media scale for pixel boxes). The HTTP
+// adapter maps it to a 400; the wrapped message carries the detail.
+var ErrANPRValidation = errors.New("ingest: invalid anpr request")
+
+// --- Sink (implemented by each app's repository; kept as an interface so this
+// package stays infra-free) -------------------------------------------------
+
+// ANPRStore is the mandatory sink for an ANPR run. The implementation MUST
+// upsert by (run.Key, run.Source.RunId) so a redelivered or re-posted run
+// replaces rather than duplicates. It is deliberately separate from
+// DetectionStore: ANPR runs live in their own collection with their own shape.
+type ANPRStore interface {
+	UpsertANPRRun(ctx context.Context, run models.ANPRRun) error
+}
+
+// MarkerStore is the optional sink for the markers derived from an ANPR run —
+// one user-facing marker per recognised plate so plate reads surface on the
+// recording timeline and in marker search. The implementation MUST upsert by a
+// stable identity — (OrganisationId, DeviceId, Name, StartTimestamp) — so an
+// at-least-once redelivery or a re-analysis of the same recording refreshes the
+// marker rather than duplicating it.
+type MarkerStore interface {
+	UpsertMarkers(ctx context.Context, markers []models.Marker) error
+}
+
+// --- Kind handler ----------------------------------------------------------
+
+// anprHandler is the automatic-number-plate-recognition kind. Its sequence is
+// the mandatory UpsertANPRRun (store the recognised plates as an ANPRRun in the
+// dedicated anpr collection) followed by the trusted-only CreateANPRMarkers,
+// which surfaces each plate as a user-facing marker — the anpr analogue of the
+// detection kind's "store the run AND adjust region-selection" pair.
+var anprHandler = Handler{
+	Kind:    "anpr",
+	Decode:  decodeANPR,
+	Actions: []Action{UpsertANPRRun{}, CreateANPRMarkers{}},
+}
+
+// ANPRDetail is the anpr kind's ReportDetail: how many plates were stored and
+// which were rejected during normalisation.
+type ANPRDetail struct {
+	PlatesStored int
+	Rejected     []api.ANPRRejection
+}
+
+// Summary implements ReportDetail.
+func (d ANPRDetail) Summary() string {
+	return fmt.Sprintf("%d plate(s), %d rejected", d.PlatesStored, len(d.Rejected))
+}
+
+// decodeANPR unmarshals the envelope payload into api.PostANPRRequest, validates
+// the envelope, normalises each plate (rejecting individual malformed plates
+// rather than the whole run), and stamps the target-derived identity onto the
+// run. An empty or fully-rejected plate list is NOT an error: ANPR legitimately
+// records that it ran and found nothing, so the run is still stored (idempotent
+// provenance). It runs once per request; the action consumes its typed output.
+func decodeANPR(scope Scope, target Target, payload json.RawMessage) (any, Report, error) {
+	var req api.PostANPRRequest
+	if err := json.Unmarshal(payload, &req); err != nil {
+		return nil, Report{}, fmt.Errorf("ingest: decode anpr payload: %w", err)
+	}
+
+	// --- envelope validation ---
+	if req.Source.RunId == "" {
+		return nil, Report{}, fmt.Errorf("%w: source.runId is required", ErrANPRValidation)
+	}
+	if len(req.Source.RunId) > maxRunIdLen {
+		return nil, Report{}, fmt.Errorf("%w: source.runId exceeds %d characters", ErrANPRValidation, maxRunIdLen)
+	}
+	if len(req.Source.Name) > maxNameLen {
+		return nil, Report{}, fmt.Errorf("%w: source.name exceeds %d characters", ErrANPRValidation, maxNameLen)
+	}
+	if len(req.Source.Version) > maxVersionLen {
+		return nil, Report{}, fmt.Errorf("%w: source.version exceeds %d characters", ErrANPRValidation, maxVersionLen)
+	}
+	if len(req.Plates) > maxPlatesPerRun {
+		return nil, Report{}, fmt.Errorf("%w: too many plates: %d exceeds limit of %d", ErrANPRValidation, len(req.Plates), maxPlatesPerRun)
+	}
+	if req.SchemaVersion != "" {
+		if _, supported := checkSchemaVersion(req.SchemaVersion); !supported {
+			return nil, Report{}, fmt.Errorf("%w: %s", ErrUnsupportedSchema, req.SchemaVersion)
+		}
+	}
+
+	// A box is only present on some plates; resolve the coordinate space once.
+	// Validation of the space is only required when at least one plate carries a
+	// box — a "no geometry" result needs no media.
+	hasAnyBox := false
+	for i := range req.Plates {
+		if plateHasBox(req.Plates[i]) {
+			hasAnyBox = true
+			break
+		}
+	}
+	normalized := req.CoordinateSpace != "pixel"
+	scaleX, scaleY := 1.0, 1.0
+	if hasAnyBox {
+		if req.CoordinateSpace != "pixel" && req.CoordinateSpace != "normalized" {
+			return nil, Report{}, fmt.Errorf("%w: coordinateSpace must be \"pixel\" or \"normalized\" when a plate carries a box, got %q", ErrANPRValidation, req.CoordinateSpace)
+		}
+		if !normalized {
+			if req.Media.Width <= 0 || req.Media.Height <= 0 {
+				return nil, Report{}, fmt.Errorf("%w: media.width and media.height are required when coordinateSpace is \"pixel\"", ErrANPRValidation)
+			}
+			scaleX = float64(req.Media.Width)
+			scaleY = float64(req.Media.Height)
+		}
+	}
+
+	// --- per-plate normalisation (individual rejects are non-fatal) ---
+	detail := ANPRDetail{Rejected: []api.ANPRRejection{}}
+	warnings := []string{}
+	storedPlates := make([]models.ANPRPlate, 0, len(req.Plates))
+	confidenceClamped := 0
+	candidatesTruncated := 0
+	sawBox := false
+
+	for i := range req.Plates {
+		in := req.Plates[i]
+
+		text := strings.TrimSpace(in.Plate)
+		if text == "" {
+			detail.Rejected = append(detail.Rejected, api.ANPRRejection{Plate: in.Plate, Frame: in.Frame, Reason: reasonPlateMissingText})
+			continue
+		}
+		if len(text) > maxPlateLen {
+			detail.Rejected = append(detail.Rejected, api.ANPRRejection{Plate: text, Frame: in.Frame, Reason: reasonPlateTooLong})
+			continue
+		}
+		if msg := validateMetaSize(fmt.Sprintf("plate %q meta", text), in.Meta); msg != "" {
+			return nil, Report{}, fmt.Errorf("%w: %s", ErrANPRValidation, msg)
+		}
+
+		var box *models.ANPRBox
+		if plateHasBox(in) {
+			b, reason := normalizeANPRBox(in, normalized, scaleX, scaleY)
+			if reason != "" {
+				detail.Rejected = append(detail.Rejected, api.ANPRRejection{Plate: text, Frame: in.Frame, Reason: reason})
+				continue
+			}
+			box = b
+			sawBox = true
+		}
+
+		conf, clamped := clampConfidence(in.Confidence)
+		if clamped {
+			confidenceClamped++
+		}
+
+		candidates := in.Candidates
+		if len(candidates) > maxCandidatesPerPlate {
+			candidatesTruncated++
+			candidates = candidates[:maxCandidatesPerPlate]
+		}
+
+		storedPlates = append(storedPlates, models.ANPRPlate{
+			Plate:       text,
+			Display:     in.Display,
+			Confidence:  conf,
+			Country:     in.Country,
+			Region:      in.Region,
+			Frame:       in.Frame,
+			TimestampMs: in.TimestampMs,
+			Box:         box,
+			Candidates:  convertCandidates(candidates),
+			Meta:        in.Meta,
+		})
+		detail.PlatesStored++
+	}
+
+	if confidenceClamped > 0 {
+		warnings = append(warnings, fmt.Sprintf("CONFIDENCE_CLAMPED: %d plate(s)", confidenceClamped))
+	}
+	if candidatesTruncated > 0 {
+		warnings = append(warnings, fmt.Sprintf("CANDIDATES_TRUNCATED: %d plate(s) over %d", candidatesTruncated, maxCandidatesPerPlate))
+	}
+	if warning, _ := checkSchemaVersion(req.SchemaVersion); warning != "" {
+		warnings = append(warnings, warning)
+	}
+
+	originalSpace := ""
+	if sawBox {
+		originalSpace = req.CoordinateSpace
+	}
+
+	run := models.ANPRRun{
+		Key:                     target.Key,
+		OrganisationId:          target.OrganisationId,
+		DeviceId:                target.DeviceId,
+		RecordingTimestamp:      target.RecordingTimestamp,
+		Source:                  req.Source,
+		SchemaVersion:           req.SchemaVersion,
+		Media:                   models.ANPRMedia{Width: req.Media.Width, Height: req.Media.Height, Fps: req.Media.Fps},
+		Plates:                  storedPlates,
+		OriginalCoordinateSpace: originalSpace,
+		CreatedAt:               time.Now().UnixMilli(),
+	}
+
+	report := Report{RunId: req.Source.RunId, Warnings: warnings, Detail: detail}
+	return run, report, nil
+}
+
+// plateHasBox reports whether a plate carries any box coordinate (in either the
+// {x,y,w,h} or {x1,y1,x2,y2} form). A partially-specified box still counts as
+// present so it can be rejected with a missing-geometry reason rather than
+// silently dropped.
+func plateHasBox(p api.ANPRPlateInput) bool {
+	return p.X != nil || p.Y != nil || p.W != nil || p.H != nil ||
+		p.X1 != nil || p.Y1 != nil || p.X2 != nil || p.Y2 != nil
+}
+
+// normalizeANPRBox converts a wire plate box into a normalised ANPRBox, or
+// returns a rejection reason. It mirrors normalizeDetectionBox: pixel boxes are
+// divided by the media scale, boxes within boundsTolerance of the frame are
+// clamped, those further out are rejected.
+func normalizeANPRBox(p api.ANPRPlateInput, alreadyNormalized bool, scaleX, scaleY float64) (*models.ANPRBox, string) {
+	var x1, y1, x2, y2 float64
+
+	switch {
+	case p.X != nil && p.Y != nil && p.W != nil && p.H != nil:
+		if *p.W <= 0 || *p.H <= 0 {
+			return nil, reasonPlateNonPositiveDim
+		}
+		x1, y1 = *p.X, *p.Y
+		x2, y2 = *p.X+*p.W, *p.Y+*p.H
+	case p.X1 != nil && p.Y1 != nil && p.X2 != nil && p.Y2 != nil:
+		x1, y1, x2, y2 = *p.X1, *p.Y1, *p.X2, *p.Y2
+		if x2 <= x1 || y2 <= y1 {
+			return nil, reasonPlateNonPositiveDim
+		}
+	default:
+		return nil, reasonPlateMissingGeom
+	}
+
+	if !alreadyNormalized {
+		if scaleX <= 0 || scaleY <= 0 {
+			return nil, reasonPlateMissingScale
+		}
+		x1, x2 = x1/scaleX, x2/scaleX
+		y1, y2 = y1/scaleY, y2/scaleY
+	}
+
+	if !withinFrame(x1, y1, x2, y2) {
+		return nil, reasonPlateBoxOutOfFrame
+	}
+
+	return &models.ANPRBox{
+		X1: clampUnit(x1),
+		Y1: clampUnit(y1),
+		X2: clampUnit(x2),
+		Y2: clampUnit(y2),
+	}, ""
+}
+
+// clampConfidence constrains a confidence to [0, 1], reporting whether it was
+// out of range so the caller can warn.
+func clampConfidence(c float64) (float64, bool) {
+	switch {
+	case c < 0:
+		return 0, true
+	case c > 1:
+		return 1, true
+	default:
+		return c, false
+	}
+}
+
+// convertCandidates maps wire candidates onto stored candidates, clamping each
+// confidence to [0, 1]. Candidates with empty text are dropped.
+func convertCandidates(in []api.ANPRCandidateInput) []models.ANPRCandidate {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]models.ANPRCandidate, 0, len(in))
+	for _, c := range in {
+		text := strings.TrimSpace(c.Plate)
+		if text == "" {
+			continue
+		}
+		conf, _ := clampConfidence(c.Confidence)
+		out = append(out, models.ANPRCandidate{Plate: text, Confidence: conf})
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// --- Action ----------------------------------------------------------------
+
+// UpsertANPRRun is the mandatory action: it persists the normalised run to the
+// anpr collection, keyed by (Key, Source.RunId). It runs for every transport —
+// an API push and a pipeline stage store the same run.
+type UpsertANPRRun struct{}
+
+func (UpsertANPRRun) Name() string       { return "upsert_anpr_run" }
+func (UpsertANPRRun) RunFor(Source) bool { return true }
+
+func (UpsertANPRRun) Apply(ctx context.Context, scope Scope, _ Target, run any) error {
+	ar, ok := run.(models.ANPRRun)
+	if !ok {
+		return fmt.Errorf("ingest: upsert expected models.ANPRRun, got %T", run)
+	}
+	if scope.ANPR == nil {
+		return errors.New("ingest: no ANPRStore configured on scope")
+	}
+	return scope.ANPR.UpsertANPRRun(ctx, ar)
+}
+
+// anprMarkerTag tags every marker created from an ANPR run so ANPR-sourced
+// markers are filterable from markers other features create.
+const anprMarkerTag = "anpr"
+
+// CreateANPRMarkers is the optional second action: it turns each recognised
+// plate into a user-facing marker (one per plate). Like the detection kind's
+// PromoteTracksToRegions it is gated to the trusted pipeline transport — an
+// external API push stores the run but does not auto-create markers (a policy
+// decision, not just routing) — and it is a no-op when no MarkerStore is wired
+// or the run recognised no plates.
+type CreateANPRMarkers struct{}
+
+func (CreateANPRMarkers) Name() string         { return "create_anpr_markers" }
+func (CreateANPRMarkers) RunFor(s Source) bool { return s == SourcePipeline }
+
+func (CreateANPRMarkers) Apply(ctx context.Context, scope Scope, _ Target, run any) error {
+	ar, ok := run.(models.ANPRRun)
+	if !ok {
+		return fmt.Errorf("ingest: create markers expected models.ANPRRun, got %T", run)
+	}
+	if scope.Markers == nil || len(ar.Plates) == 0 {
+		// No marker sink wired (a transport that only stores the run), or nothing
+		// recognised — nothing to surface.
+		return nil
+	}
+	markers := make([]models.Marker, 0, len(ar.Plates))
+	for i := range ar.Plates {
+		markers = append(markers, anprPlateToMarker(ar, ar.Plates[i]))
+	}
+	return scope.Markers.UpsertMarkers(ctx, markers)
+}
+
+// anprPlateToMarker maps one recognised plate onto a marker. The marker is a
+// point-in-time event at the plate's representative time (the recording start
+// plus the read's offset), named for the human-readable plate, tagged "anpr"
+// so ANPR-sourced markers are filterable, with the read summarised in the
+// description. Marker timestamps are in seconds (the Marker contract), so the
+// plate's millisecond offset is converted. The marker's _id is left to the
+// store to assign on first insert so a replay refreshes rather than renames.
+func anprPlateToMarker(run models.ANPRRun, plate models.ANPRPlate) models.Marker {
+	name := plate.Display
+	if name == "" {
+		name = plate.Plate
+	}
+
+	start := run.RecordingTimestamp + plate.TimestampMs/1000
+
+	desc := fmt.Sprintf("ANPR plate %s", name)
+	if plate.Country != "" {
+		desc += fmt.Sprintf(" (%s)", plate.Country)
+	}
+	if plate.Confidence > 0 {
+		desc += fmt.Sprintf(", confidence %.2f", plate.Confidence)
+	}
+
+	return models.Marker{
+		DeviceId:       run.DeviceId,
+		OrganisationId: run.OrganisationId,
+		StartTimestamp: start,
+		EndTimestamp:   start,
+		Name:           name,
+		Tags:           []models.MarkerTag{{Name: anprMarkerTag}},
+		Description:    desc,
+	}
+}

--- a/pkg/ingest/anpr_test.go
+++ b/pkg/ingest/anpr_test.go
@@ -1,0 +1,357 @@
+package ingest
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/uug-ai/models/pkg/models"
+)
+
+// --- fakes -----------------------------------------------------------------
+
+type fakeANPRStore struct {
+	runs []models.ANPRRun
+	err  error
+}
+
+func (f *fakeANPRStore) UpsertANPRRun(_ context.Context, run models.ANPRRun) error {
+	if f.err != nil {
+		return f.err
+	}
+	f.runs = append(f.runs, run)
+	return nil
+}
+
+type fakeMarkerStore struct {
+	markers []models.Marker
+	err     error
+}
+
+func (f *fakeMarkerStore) UpsertMarkers(_ context.Context, markers []models.Marker) error {
+	if f.err != nil {
+		return f.err
+	}
+	f.markers = append(f.markers, markers...)
+	return nil
+}
+
+func newANPRScope(src Source) (Scope, *fakeANPRStore) {
+	store := &fakeANPRStore{}
+	return Scope{Source: src, ANPR: store}, store
+}
+
+func anprPayload(t *testing.T, body map[string]any) json.RawMessage {
+	t.Helper()
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	return raw
+}
+
+// --- tests -----------------------------------------------------------------
+
+func TestIngestANPR_PixelNormalizesAndStores(t *testing.T) {
+	scope, store := newANPRScope(SourcePipeline)
+
+	payload := anprPayload(t, map[string]any{
+		"schemaVersion":   "1.0",
+		"source":          map[string]any{"kind": "model", "name": "acme-anpr", "version": "2", "runId": "RUN-A"},
+		"coordinateSpace": "pixel",
+		"media":           map[string]any{"width": 1000, "height": 500},
+		"plates": []any{
+			map[string]any{
+				"plate": "1ABC234", "display": "1-ABC-234", "confidence": 0.92,
+				"country": "BE", "frame": 12, "timestampMs": 480,
+				"x1": 100, "y1": 50, "x2": 300, "y2": 250,
+				"candidates": []any{
+					map[string]any{"plate": "1ABC234", "confidence": 0.92},
+					map[string]any{"plate": "1A8C234", "confidence": 0.41},
+				},
+			},
+		},
+	})
+
+	report, err := Ingest(context.Background(), scope, target(), "anpr", payload)
+	if err != nil {
+		t.Fatalf("Ingest: %v", err)
+	}
+	detail := report.Detail.(ANPRDetail)
+	if detail.PlatesStored != 1 {
+		t.Fatalf("want 1 plate stored, got %d", detail.PlatesStored)
+	}
+	if report.RunId != "RUN-A" {
+		t.Fatalf("want RunId RUN-A, got %q", report.RunId)
+	}
+	if len(store.runs) != 1 {
+		t.Fatalf("want 1 stored run, got %d", len(store.runs))
+	}
+
+	run := store.runs[0]
+	if run.Key != "cam-1_1700000000_rec" || run.OrganisationId != "org-9" || run.DeviceId != "dev-3" {
+		t.Fatalf("target identity not stamped: %+v", run)
+	}
+	if run.RecordingTimestamp != 1700000000 {
+		t.Fatalf("want recordingTimestamp stamped, got %d", run.RecordingTimestamp)
+	}
+	if run.OriginalCoordinateSpace != "pixel" {
+		t.Fatalf("want originalCoordinateSpace pixel, got %q", run.OriginalCoordinateSpace)
+	}
+
+	p := run.Plates[0]
+	if p.Plate != "1ABC234" || p.Display != "1-ABC-234" || p.Country != "BE" {
+		t.Fatalf("plate fields not preserved: %+v", p)
+	}
+	if p.Box == nil {
+		t.Fatalf("want a normalised box, got nil")
+	}
+	if !approx(p.Box.X1, 0.1) || !approx(p.Box.Y1, 0.1) || !approx(p.Box.X2, 0.3) || !approx(p.Box.Y2, 0.5) {
+		t.Fatalf("box not normalised to [0,1]: %+v", p.Box)
+	}
+	if len(p.Candidates) != 2 || p.Candidates[1].Plate != "1A8C234" {
+		t.Fatalf("candidates not preserved: %+v", p.Candidates)
+	}
+}
+
+func TestIngestANPR_CreatesMarkerPerPlate(t *testing.T) {
+	anprStore := &fakeANPRStore{}
+	markerStore := &fakeMarkerStore{}
+	scope := Scope{Source: SourcePipeline, ANPR: anprStore, Markers: markerStore}
+
+	payload := anprPayload(t, map[string]any{
+		"source": map[string]any{"kind": "model", "name": "a", "version": "1", "runId": "RUN-M"},
+		"plates": []any{
+			map[string]any{"plate": "1ABC234", "display": "1-ABC-234", "country": "BE", "confidence": 0.9, "timestampMs": 2000},
+			map[string]any{"plate": "ZZ999"},
+		},
+	})
+
+	if _, err := Ingest(context.Background(), scope, target(), "anpr", payload); err != nil {
+		t.Fatalf("Ingest: %v", err)
+	}
+	if len(markerStore.markers) != 2 {
+		t.Fatalf("want one marker per plate (2), got %d", len(markerStore.markers))
+	}
+
+	m := markerStore.markers[0]
+	if m.Name != "1-ABC-234" {
+		t.Errorf("marker name = %q, want the display plate \"1-ABC-234\"", m.Name)
+	}
+	// target() stamps recordingTimestamp 1700000000; +2000ms => +2s.
+	if m.StartTimestamp != 1700000002 || m.EndTimestamp != 1700000002 {
+		t.Errorf("marker timing = [%d,%d], want point-in-time 1700000002", m.StartTimestamp, m.EndTimestamp)
+	}
+	if m.DeviceId != "dev-3" || m.OrganisationId != "org-9" {
+		t.Errorf("marker RBAC not stamped: device=%q org=%q", m.DeviceId, m.OrganisationId)
+	}
+	if len(m.Tags) != 1 || m.Tags[0].Name != "anpr" {
+		t.Errorf("marker tags = %+v, want a single \"anpr\" tag", m.Tags)
+	}
+	// The second plate has no display, so the name falls back to the plate text.
+	if markerStore.markers[1].Name != "ZZ999" {
+		t.Errorf("marker[1] name = %q, want fallback \"ZZ999\"", markerStore.markers[1].Name)
+	}
+}
+
+func TestIngestANPR_APISourceSkipsMarkers(t *testing.T) {
+	anprStore := &fakeANPRStore{}
+	markerStore := &fakeMarkerStore{}
+	scope := Scope{Source: SourceAPI, ANPR: anprStore, Markers: markerStore}
+
+	payload := anprPayload(t, map[string]any{
+		"source": map[string]any{"kind": "model", "name": "a", "version": "1", "runId": "RUN-N"},
+		"plates": []any{map[string]any{"plate": "1ABC234"}},
+	})
+
+	if _, err := Ingest(context.Background(), scope, target(), "anpr", payload); err != nil {
+		t.Fatalf("Ingest: %v", err)
+	}
+	if len(anprStore.runs) != 1 {
+		t.Fatalf("want the run stored for an API push, got %d", len(anprStore.runs))
+	}
+	if len(markerStore.markers) != 0 {
+		t.Fatalf("want no markers for an API push (trusted-pipeline-only), got %d", len(markerStore.markers))
+	}
+}
+
+func TestIngestANPR_XYWHForm(t *testing.T) {
+	scope, store := newANPRScope(SourcePipeline)
+	payload := anprPayload(t, map[string]any{
+		"source":          map[string]any{"kind": "model", "name": "a", "version": "1", "runId": "RUN-B"},
+		"coordinateSpace": "pixel",
+		"media":           map[string]any{"width": 200, "height": 100},
+		"plates": []any{
+			map[string]any{"plate": "XY99", "x": 20, "y": 10, "w": 40, "h": 20},
+		},
+	})
+	if _, err := Ingest(context.Background(), scope, target(), "anpr", payload); err != nil {
+		t.Fatalf("Ingest: %v", err)
+	}
+	b := store.runs[0].Plates[0].Box
+	if b == nil || !approx(b.X1, 0.1) || !approx(b.Y1, 0.1) || !approx(b.X2, 0.3) || !approx(b.Y2, 0.3) {
+		t.Fatalf("xywh box not normalised: %+v", b)
+	}
+}
+
+func TestIngestANPR_NormalizedPassthrough(t *testing.T) {
+	scope, store := newANPRScope(SourcePipeline)
+	payload := anprPayload(t, map[string]any{
+		"source":          map[string]any{"kind": "model", "name": "a", "version": "1", "runId": "RUN-C"},
+		"coordinateSpace": "normalized",
+		"plates": []any{
+			map[string]any{"plate": "ABC", "x1": 0.2, "y1": 0.2, "x2": 0.4, "y2": 0.4},
+		},
+	})
+	if _, err := Ingest(context.Background(), scope, target(), "anpr", payload); err != nil {
+		t.Fatalf("Ingest: %v", err)
+	}
+	b := store.runs[0].Plates[0].Box
+	if b == nil || !approx(b.X1, 0.2) || !approx(b.X2, 0.4) {
+		t.Fatalf("normalized box not passed through: %+v", b)
+	}
+}
+
+func TestIngestANPR_NoBoxIsValid(t *testing.T) {
+	scope, store := newANPRScope(SourcePipeline)
+	payload := anprPayload(t, map[string]any{
+		"source": map[string]any{"kind": "import", "name": "a", "version": "1", "runId": "RUN-D"},
+		"plates": []any{
+			map[string]any{"plate": "NOBOX1", "confidence": 0.5},
+		},
+	})
+	report, err := Ingest(context.Background(), scope, target(), "anpr", payload)
+	if err != nil {
+		t.Fatalf("Ingest: %v", err)
+	}
+	if d := report.Detail.(ANPRDetail); d.PlatesStored != 1 {
+		t.Fatalf("want 1 plate stored, got %d", d.PlatesStored)
+	}
+	run := store.runs[0]
+	if run.Plates[0].Box != nil {
+		t.Fatalf("want nil box, got %+v", run.Plates[0].Box)
+	}
+	if run.OriginalCoordinateSpace != "" {
+		t.Fatalf("want empty originalCoordinateSpace when no box, got %q", run.OriginalCoordinateSpace)
+	}
+}
+
+func TestIngestANPR_EmptyPlatesStillStoresRun(t *testing.T) {
+	scope, store := newANPRScope(SourcePipeline)
+	payload := anprPayload(t, map[string]any{
+		"source": map[string]any{"kind": "pipeline", "name": "a", "version": "1", "runId": "RUN-E"},
+		"plates": []any{},
+	})
+	report, err := Ingest(context.Background(), scope, target(), "anpr", payload)
+	if err != nil {
+		t.Fatalf("Ingest: empty plates must not error, got %v", err)
+	}
+	if d := report.Detail.(ANPRDetail); d.PlatesStored != 0 {
+		t.Fatalf("want 0 plates stored, got %d", d.PlatesStored)
+	}
+	if len(store.runs) != 1 {
+		t.Fatalf("want the empty run still stored for provenance, got %d runs", len(store.runs))
+	}
+}
+
+func TestIngestANPR_RejectsMissingRunId(t *testing.T) {
+	scope, _ := newANPRScope(SourcePipeline)
+	payload := anprPayload(t, map[string]any{
+		"source": map[string]any{"kind": "model", "name": "a", "version": "1"},
+		"plates": []any{map[string]any{"plate": "ABC"}},
+	})
+	_, err := Ingest(context.Background(), scope, target(), "anpr", payload)
+	if !errors.Is(err, ErrANPRValidation) {
+		t.Fatalf("want ErrANPRValidation, got %v", err)
+	}
+}
+
+func TestIngestANPR_DropsBadPlates(t *testing.T) {
+	scope, store := newANPRScope(SourcePipeline)
+	payload := anprPayload(t, map[string]any{
+		"source":          map[string]any{"kind": "model", "name": "a", "version": "1", "runId": "RUN-F"},
+		"coordinateSpace": "normalized",
+		"plates": []any{
+			map[string]any{"plate": ""}, // missing text -> dropped
+			map[string]any{"plate": "OOF", "x1": 0.5, "y1": 0.5, "x2": 2.0, "y2": 2.0}, // out of frame -> dropped
+			map[string]any{"plate": "GOOD", "x1": 0.1, "y1": 0.1, "x2": 0.2, "y2": 0.2},
+		},
+	})
+	report, err := Ingest(context.Background(), scope, target(), "anpr", payload)
+	if err != nil {
+		t.Fatalf("Ingest: %v", err)
+	}
+	detail := report.Detail.(ANPRDetail)
+	if detail.PlatesStored != 1 {
+		t.Fatalf("want 1 surviving plate, got %d", detail.PlatesStored)
+	}
+	if len(detail.Rejected) != 2 {
+		t.Fatalf("want 2 rejected plates, got %+v", detail.Rejected)
+	}
+	if store.runs[0].Plates[0].Plate != "GOOD" {
+		t.Fatalf("want only GOOD stored, got %+v", store.runs[0].Plates)
+	}
+}
+
+func TestIngestANPR_ClampsConfidence(t *testing.T) {
+	scope, store := newANPRScope(SourcePipeline)
+	payload := anprPayload(t, map[string]any{
+		"source": map[string]any{"kind": "model", "name": "a", "version": "1", "runId": "RUN-G"},
+		"plates": []any{
+			map[string]any{"plate": "HI", "confidence": 1.7},
+			map[string]any{"plate": "LO", "confidence": -0.3},
+		},
+	})
+	report, err := Ingest(context.Background(), scope, target(), "anpr", payload)
+	if err != nil {
+		t.Fatalf("Ingest: %v", err)
+	}
+	if !approx(store.runs[0].Plates[0].Confidence, 1.0) || !approx(store.runs[0].Plates[1].Confidence, 0.0) {
+		t.Fatalf("confidence not clamped: %+v", store.runs[0].Plates)
+	}
+	foundWarning := false
+	for _, w := range report.Warnings {
+		if w == "CONFIDENCE_CLAMPED: 2 plate(s)" {
+			foundWarning = true
+		}
+	}
+	if !foundWarning {
+		t.Fatalf("want CONFIDENCE_CLAMPED warning, got %v", report.Warnings)
+	}
+}
+
+func TestIngestANPR_PixelBoxRequiresMedia(t *testing.T) {
+	scope, _ := newANPRScope(SourcePipeline)
+	payload := anprPayload(t, map[string]any{
+		"source":          map[string]any{"kind": "model", "name": "a", "version": "1", "runId": "RUN-H"},
+		"coordinateSpace": "pixel",
+		"plates": []any{
+			map[string]any{"plate": "ABC", "x1": 10, "y1": 10, "x2": 20, "y2": 20},
+		},
+	})
+	_, err := Ingest(context.Background(), scope, target(), "anpr", payload)
+	if !errors.Is(err, ErrANPRValidation) {
+		t.Fatalf("want ErrANPRValidation for pixel box without media, got %v", err)
+	}
+}
+
+func TestIngestANPR_NoStoreConfigured(t *testing.T) {
+	payload := anprPayload(t, map[string]any{
+		"source": map[string]any{"kind": "model", "name": "a", "version": "1", "runId": "RUN-I"},
+		"plates": []any{map[string]any{"plate": "ABC"}},
+	})
+	scope := Scope{Source: SourcePipeline} // no ANPR sink
+	_, err := Ingest(context.Background(), scope, target(), "anpr", payload)
+	if err == nil {
+		t.Fatalf("want error when no ANPRStore configured")
+	}
+}
+
+func TestIngestANPR_UnknownKindUnaffected(t *testing.T) {
+	scope, _ := newANPRScope(SourcePipeline)
+	_, err := Ingest(context.Background(), scope, target(), "nope", json.RawMessage(`{}`))
+	if !errors.Is(err, ErrUnknownKind) {
+		t.Fatalf("want ErrUnknownKind, got %v", err)
+	}
+}

--- a/pkg/ingest/detection.go
+++ b/pkg/ingest/detection.go
@@ -81,6 +81,19 @@ var detectionHandler = Handler{
 	Actions: []Action{UpsertDetectionRun{}, PromoteTracksToRegions{}},
 }
 
+// DetectionDetail is the detection kind's ReportDetail: how many tracks and
+// boxes were stored and which boxes were rejected during normalisation.
+type DetectionDetail struct {
+	TracksStored int
+	BoxesStored  int
+	Rejected     []api.DetectionRejection
+}
+
+// Summary implements ReportDetail.
+func (d DetectionDetail) Summary() string {
+	return fmt.Sprintf("%d track(s), %d box(es), %d rejected", d.TracksStored, d.BoxesStored, len(d.Rejected))
+}
+
 // decodeDetection unmarshals the envelope payload into the shared
 // api.PostDetectionsRequest (the exact same type the HTTP door binds), routes
 // by Task to the matching validator/normaliser, and stamps the target-derived
@@ -110,7 +123,8 @@ func decodeDetection(scope Scope, target Target, payload json.RawMessage) (any, 
 
 	// A run in which every box was rejected stores nothing — surface it so the
 	// adapter can reject the whole request rather than persist an empty run.
-	if report.BoxesStored == 0 {
+	detail, _ := report.Detail.(DetectionDetail)
+	if detail.BoxesStored == 0 {
 		report.RunId = req.Source.RunId
 		return nil, report, ErrAllBoxesRejected
 	}
@@ -166,7 +180,6 @@ type TaskHandler interface {
 var taskRegistry = map[string]TaskHandler{
 	models.DetectionTask: boxTask{}, // "detection" (default / box)
 	"pose":               boxTask{}, // pose producer emits the detection contract
-	// "anpr": anprTask{},
 }
 
 // --- box task --------------------------------------------------------------
@@ -250,10 +263,8 @@ func (boxTask) Validate(req api.PostDetectionsRequest) error {
 // and report.BoxesStored stays zero so decodeDetection raises
 // ErrAllBoxesRejected.
 func (boxTask) Normalize(req api.PostDetectionsRequest) (models.DetectionRun, Report) {
-	report := Report{
-		Rejected: []api.DetectionRejection{},
-		Warnings: []string{},
-	}
+	detail := DetectionDetail{Rejected: []api.DetectionRejection{}}
+	warnings := []string{}
 
 	normalized := req.CoordinateSpace != "pixel"
 	scaleX, scaleY := 1.0, 1.0
@@ -297,7 +308,7 @@ func (boxTask) Normalize(req api.PostDetectionsRequest) (models.DetectionRun, Re
 
 			box, reason := normalizeDetectionBox(b, normalized, scaleX, scaleY)
 			if reason != "" {
-				report.Rejected = append(report.Rejected, api.DetectionRejection{
+				detail.Rejected = append(detail.Rejected, api.DetectionRejection{
 					TrackId: trackId,
 					Frame:   b.Frame,
 					Reason:  reason,
@@ -319,7 +330,7 @@ func (boxTask) Normalize(req api.PostDetectionsRequest) (models.DetectionRun, Re
 				duplicateFrames++
 			} else {
 				frames = append(frames, b.Frame)
-				report.BoxesStored++
+				detail.BoxesStored++
 			}
 			// Last write wins for a repeated frame within the same track.
 			frameCoords[b.Frame] = box
@@ -344,23 +355,25 @@ func (boxTask) Normalize(req api.PostDetectionsRequest) (models.DetectionRun, Re
 			ClassId:          t.ClassId,
 			Shape:            t.Shape,
 		})
-		report.TracksStored++
+		detail.TracksStored++
 	}
 
 	if timestampMismatches > 0 {
-		report.Warnings = append(report.Warnings, fmt.Sprintf("TIMESTAMP_FRAME_MISMATCH: %d box(es)", timestampMismatches))
+		warnings = append(warnings, fmt.Sprintf("TIMESTAMP_FRAME_MISMATCH: %d box(es)", timestampMismatches))
 	}
 	if frameOutOfRange > 0 {
-		report.Warnings = append(report.Warnings, fmt.Sprintf("FRAME_OUT_OF_RANGE: %d box(es)", frameOutOfRange))
+		warnings = append(warnings, fmt.Sprintf("FRAME_OUT_OF_RANGE: %d box(es)", frameOutOfRange))
 	}
 	if duplicateFrames > 0 {
-		report.Warnings = append(report.Warnings, fmt.Sprintf("DUPLICATE_FRAME: %d box(es) overwritten", duplicateFrames))
+		warnings = append(warnings, fmt.Sprintf("DUPLICATE_FRAME: %d box(es) overwritten", duplicateFrames))
 	}
 	if warning, _ := checkSchemaVersion(req.SchemaVersion); warning != "" {
-		report.Warnings = append(report.Warnings, warning)
+		warnings = append(warnings, warning)
 	}
 
-	if totalBoxes > 0 && report.BoxesStored == 0 {
+	report := Report{Warnings: warnings, Detail: detail}
+
+	if totalBoxes > 0 && detail.BoxesStored == 0 {
 		// Nothing survived; the empty report drives ErrAllBoxesRejected upstream.
 		return models.DetectionRun{}, report
 	}

--- a/pkg/ingest/detection_test.go
+++ b/pkg/ingest/detection_test.go
@@ -109,8 +109,9 @@ func TestIngest_PixelNormalizesAndStores(t *testing.T) {
 		t.Errorf("normalised box = %+v, want {0.1,0.1,0.3,0.5}", box)
 	}
 
-	if report.TracksStored != 1 || report.BoxesStored != 1 || report.RunId != "RUN-1" {
-		t.Errorf("report = %+v", report)
+	detail := report.Detail.(DetectionDetail)
+	if detail.TracksStored != 1 || detail.BoxesStored != 1 || report.RunId != "RUN-1" {
+		t.Errorf("report = %+v detail = %+v", report, detail)
 	}
 }
 
@@ -189,11 +190,12 @@ func TestIngest_OutOfFrameBoxRejected(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Ingest: %v", err)
 	}
-	if report.BoxesStored != 1 {
-		t.Errorf("boxesStored = %d, want 1", report.BoxesStored)
+	detail := report.Detail.(DetectionDetail)
+	if detail.BoxesStored != 1 {
+		t.Errorf("boxesStored = %d, want 1", detail.BoxesStored)
 	}
-	if len(report.Rejected) != 1 || report.Rejected[0].Reason != "box_out_of_frame" || report.Rejected[0].Frame != 1 {
-		t.Errorf("rejected = %+v, want one box_out_of_frame at frame 1", report.Rejected)
+	if len(detail.Rejected) != 1 || detail.Rejected[0].Reason != "box_out_of_frame" || detail.Rejected[0].Frame != 1 {
+		t.Errorf("rejected = %+v, want one box_out_of_frame at frame 1", detail.Rejected)
 	}
 	if got := len(store.runs[0].Tracks[0].FrameCoordinates); got != 1 {
 		t.Errorf("stored frame coords = %d, want 1", got)
@@ -249,8 +251,8 @@ func TestIngest_PoseUsesDetectionContract(t *testing.T) {
 	if store.runs[0].Task != "pose" {
 		t.Errorf("run.Task = %q, want \"pose\"", store.runs[0].Task)
 	}
-	if report.RunId != "RUN-POSE" || report.BoxesStored != 1 {
-		t.Errorf("report = %+v", report)
+	if detail := report.Detail.(DetectionDetail); report.RunId != "RUN-POSE" || detail.BoxesStored != 1 {
+		t.Errorf("report = %+v detail = %+v", report, detail)
 	}
 }
 

--- a/pkg/ingest/ingest.go
+++ b/pkg/ingest/ingest.go
@@ -12,12 +12,14 @@
 //
 // Routing happens on two independent axes that must not be conflated:
 //
-//   - Kind  (the operation) — what is this result? detection vs thumbnail vs
-//     sprite. Different shapes, different sinks, different action sequences.
-//     Routed here, by the handlers registry.
-//   - Task  (within a kind) — which flavour? box / anpr / pose inside
-//     detection. All share one contract and one collection. Routed *inside*
-//     the kind handler (see detection.go).
+//   - Kind  (the operation) — what is this result? detection vs anpr vs
+//     thumbnail vs sprite. Different shapes, different sinks, different action
+//     sequences. Routed here, by the handlers registry.
+//   - Task  (within a kind) — which flavour? box / pose inside detection. All
+//     tasks of a kind share one contract and one collection. Routed *inside*
+//     the kind handler (see detection.go). A producer whose result has a
+//     genuinely different shape (e.g. anpr: recognised text, not boxes) is its
+//     own kind, not a task.
 package ingest
 
 import (
@@ -25,8 +27,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-
-	"github.com/uug-ai/models/pkg/api"
 )
 
 // ErrUnknownKind is returned when no handler is registered for the requested
@@ -79,16 +79,36 @@ type Scope struct {
 	Detections DetectionStore
 	// Regions is the sink for the optional promote-tracks-to-redaction effect.
 	Regions RegionPromoter
+	// ANPR is the sink for the mandatory anpr-run upsert. Only required by an app
+	// that routes the "anpr" kind; nil otherwise.
+	ANPR ANPRStore
+	// Markers is the sink for the optional create-markers effect (one marker per
+	// recognised ANPR plate). Wired only by a transport that wants the side
+	// effect (the trusted pipeline); nil otherwise (the action no-ops).
+	Markers MarkerStore
 }
 
-// Report summarises what a handler stored, mirroring api.PostDetectionsResponse
-// so an HTTP adapter can return it directly and a queue adapter can log it.
+// Report is the kind-agnostic envelope every handler returns. Only the
+// genuinely universal fields live here — the run's id and any non-fatal
+// warnings — so adding a kind never widens this struct. The kind-specific
+// summary (what and how much was stored, which items were rejected) lives in
+// Detail, a value the kind owns: a queue adapter logs Detail.Summary()
+// kind-agnostically, and an HTTP adapter type-asserts Detail to the concrete
+// type for its response body (it already branches by kind).
 type Report struct {
-	RunId        string
-	TracksStored int
-	BoxesStored  int
-	Rejected     []api.DetectionRejection
-	Warnings     []string
+	RunId    string
+	Warnings []string
+	Detail   ReportDetail
+}
+
+// ReportDetail is a kind's own result summary. Each kind defines a concrete
+// type (DetectionDetail, ANPRDetail, …). Summary keeps logging kind-agnostic;
+// a caller that needs the typed counts asserts on the concrete type — it always
+// knows the kind it asked Ingest to run.
+type ReportDetail interface {
+	// Summary is a short, human-readable line for logs, e.g.
+	// "3 track(s), 50 box(es), 1 rejected".
+	Summary() string
 }
 
 // Action is one idempotent effect in a handler's ordered sequence. Each action
@@ -121,6 +141,7 @@ type Handler struct {
 // never grows a case.
 var handlers = map[string]Handler{
 	detectionHandler.Kind: detectionHandler,
+	anprHandler.Kind:      anprHandler,
 	// "thumbnail": thumbnailHandler, "sprite": spriteHandler — migrated from
 	// the analyser's hardcoded switch later.
 }

--- a/pkg/models/anpr.go
+++ b/pkg/models/anpr.go
@@ -1,0 +1,114 @@
+package models
+
+import "go.mongodb.org/mongo-driver/bson/primitive"
+
+// ANPRRun is one automatic-number-plate-recognition run for a recording. Like
+// DetectionRun it is stored in its own dedicated collection ("anpr") keyed by
+// the recording (Key) so a recording can accumulate many runs without bloating
+// its analysis document, and each run is upserted by (Key, Source.RunId) so a
+// re-post or at-least-once redelivery replaces rather than duplicates.
+//
+// ANPR deliberately does NOT reuse the detection/redaction track shape
+// (FaceRedactionTrack): a plate read is recognised *text* with candidate reads
+// and a jurisdiction, not a per-frame box trajectory selected for redaction.
+// The two share only provenance conventions (a Source carrying the upsert key).
+type ANPRRun struct {
+	// Id is the MongoDB document id, assigned on first insert.
+	Id primitive.ObjectID `json:"id,omitempty" bson:"_id,omitempty"`
+	// Key is the recording/media key the run belongs to — the stable identity
+	// the collection is keyed by (survives re-analysis).
+	Key string `json:"key,omitempty" bson:"key,omitempty"`
+	// OrganisationId scopes the run to the owning organisation. Never serialised
+	// out (consistent with DetectionRun).
+	OrganisationId string `json:"-" bson:"organisationId,omitempty"`
+	// DeviceId is denormalised from the recording for convenient filtering and
+	// cascade cleanup; it is not authoritative.
+	DeviceId string `json:"deviceId,omitempty" bson:"deviceId,omitempty"`
+	// Source identifies the producer and carries RunId, the natural upsert key.
+	Source ANPRSource `json:"source" bson:"source"`
+	// SchemaVersion is the producer's payload schema (optional).
+	SchemaVersion string `json:"schemaVersion,omitempty" bson:"schemaVersion,omitempty"`
+	// Media describes the recording the plates were read against; kept so a
+	// normalised plate box can be rendered back at pixel scale.
+	Media ANPRMedia `json:"media,omitempty" bson:"media,omitempty"`
+	// Plates are the recognised plates, stored verbatim after the box (if any)
+	// is normalised to the [0, 1] frame.
+	Plates []ANPRPlate `json:"plates" bson:"plates"`
+	// OriginalCoordinateSpace records the space the producer sent plate boxes in
+	// ("pixel" or "normalized") before the server normalised them. Empty when no
+	// plate carried a box.
+	OriginalCoordinateSpace string `json:"originalCoordinateSpace,omitempty" bson:"originalCoordinateSpace,omitempty"`
+	// CreatedAt is set by the server when the run is first stored (epoch millis).
+	CreatedAt int64 `json:"createdAt,omitempty" bson:"createdAt,omitempty"`
+	// UpdatedAt is set by the server every time the run is written (epoch millis).
+	UpdatedAt int64 `json:"updatedAt,omitempty" bson:"updatedAt,omitempty"`
+	// RecordingTimestamp is the start time (epoch seconds) of the recording,
+	// denormalised on write so cleanup expires the run on the recording's
+	// retention clock rather than the (possibly much later) post time.
+	RecordingTimestamp int64 `json:"recordingTimestamp,omitempty" bson:"recordingTimestamp,omitempty"`
+}
+
+// ANPRSource identifies the producer of an ANPR run. RunId is the natural key
+// the upsert matches on for a recording.
+type ANPRSource struct {
+	Kind    string `json:"kind" bson:"kind"` // pipeline | model | import
+	Name    string `json:"name" bson:"name"` // producer identifier
+	Version string `json:"version" bson:"version"`
+	RunId   string `json:"runId" bson:"runId"` // ULID/UUID; upsert key
+}
+
+// ANPRMedia describes the recording an ANPR run was produced against. Width and
+// Height let a normalised plate box be projected back to pixels.
+type ANPRMedia struct {
+	Width  int     `json:"width,omitempty" bson:"width,omitempty"`
+	Height int     `json:"height,omitempty" bson:"height,omitempty"`
+	Fps    float64 `json:"fps,omitempty" bson:"fps,omitempty"`
+}
+
+// ANPRPlate is one recognised number plate. The recognised text (Plate) is the
+// searchable, normalised form; Display preserves the producer's human-readable
+// rendering. Candidates carry the alternative reads an OCR engine ranked below
+// the chosen Plate so a consumer can re-rank or audit the recognition.
+type ANPRPlate struct {
+	// Plate is the recognised registration in a normalised, searchable form
+	// (uppercase, no separators), e.g. "1ABC234".
+	Plate string `json:"plate" bson:"plate"`
+	// Display is the optional human-readable rendering, e.g. "1-ABC-234".
+	Display string `json:"display,omitempty" bson:"display,omitempty"`
+	// Confidence is the chosen read's confidence in [0, 1].
+	Confidence float64 `json:"confidence,omitempty" bson:"confidence,omitempty"`
+	// Country is the ISO 3166-1 alpha-2 jurisdiction, e.g. "BE" (optional).
+	Country string `json:"country,omitempty" bson:"country,omitempty"`
+	// Region is the sub-jurisdiction (state/province) when the producer reports
+	// one, e.g. "CA" (optional).
+	Region string `json:"region,omitempty" bson:"region,omitempty"`
+	// Frame is the representative frame the chosen read came from.
+	Frame int64 `json:"frame,omitempty" bson:"frame,omitempty"`
+	// TimestampMs is the representative time (ms into the recording) of the read.
+	TimestampMs int64 `json:"timestampMs,omitempty" bson:"timestampMs,omitempty"`
+	// Box is the plate's location at the representative frame, normalised to the
+	// [0, 1] frame. Nil when the producer reported no geometry.
+	Box *ANPRBox `json:"box,omitempty" bson:"box,omitempty"`
+	// Candidates are alternative reads ranked below Plate, highest confidence
+	// first (optional).
+	Candidates []ANPRCandidate `json:"candidates,omitempty" bson:"candidates,omitempty"`
+	// Meta carries producer-specific extras (e.g. vehicle make/colour) without
+	// expanding the core contract. Capped on ingest.
+	Meta map[string]interface{} `json:"meta,omitempty" bson:"meta,omitempty"`
+}
+
+// ANPRCandidate is one alternative plate read with its confidence in [0, 1].
+type ANPRCandidate struct {
+	Plate      string  `json:"plate" bson:"plate"`
+	Confidence float64 `json:"confidence,omitempty" bson:"confidence,omitempty"`
+}
+
+// ANPRBox is a plate bounding box normalised to the [0, 1] frame. It is
+// intentionally separate from the redaction TrackBox: an ANPR box is a single
+// location for a recognised plate, not an editable per-frame redaction region.
+type ANPRBox struct {
+	X1 float64 `json:"x1" bson:"x1"`
+	Y1 float64 `json:"y1" bson:"y1"`
+	X2 float64 `json:"x2" bson:"x2"`
+	Y2 float64 `json:"y2" bson:"y2"`
+}

--- a/pkg/models/workflow.go
+++ b/pkg/models/workflow.go
@@ -85,7 +85,7 @@ type Workflow struct {
 	Edges          []WorkflowEdge     `json:"edges" bson:"edges"`
 	UserId         string             `json:"user_id" bson:"user_id,omitempty"`
 	Username       string             `json:"username" bson:"username,omitempty"`
-	OrganisationId string             `json:"organisationId" bson:"organisationId,omitempty"`
+	OrganisationId string             `json:"organisation_id" bson:"organisation_id,omitempty"`
 	CreatedAt      int64              `json:"created_at" bson:"created_at,omitempty"`
 	UpdatedAt      int64              `json:"updated_at" bson:"updated_at,omitempty"`
 }

--- a/pkg/models/workflow.go
+++ b/pkg/models/workflow.go
@@ -76,18 +76,18 @@ type WorkflowTrigger struct {
 // and the edges that route between them. Trigger says what activates it; the
 // nodes/edges say what runs.
 type Workflow struct {
-	Id           primitive.ObjectID `json:"id" bson:"_id,omitempty"`
-	Name         string             `json:"name" bson:"name,omitempty"`
-	Description  string             `json:"description" bson:"description,omitempty"`
-	Enabled      bool               `json:"enabled" bson:"enabled"`
-	Trigger      *WorkflowTrigger   `json:"trigger,omitempty" bson:"trigger,omitempty"`
-	Nodes        []WorkflowNode     `json:"nodes" bson:"nodes"`
-	Edges        []WorkflowEdge     `json:"edges" bson:"edges"`
-	UserId       string             `json:"user_id" bson:"user_id,omitempty"`
-	Username     string             `json:"username" bson:"username,omitempty"`
-	MasterUserId string             `json:"master_user_id" bson:"master_user_id,omitempty"`
-	CreatedAt    int64              `json:"created_at" bson:"created_at,omitempty"`
-	UpdatedAt    int64              `json:"updated_at" bson:"updated_at,omitempty"`
+	Id             primitive.ObjectID `json:"id" bson:"_id,omitempty"`
+	Name           string             `json:"name" bson:"name,omitempty"`
+	Description    string             `json:"description" bson:"description,omitempty"`
+	Enabled        bool               `json:"enabled" bson:"enabled"`
+	Trigger        *WorkflowTrigger   `json:"trigger,omitempty" bson:"trigger,omitempty"`
+	Nodes          []WorkflowNode     `json:"nodes" bson:"nodes"`
+	Edges          []WorkflowEdge     `json:"edges" bson:"edges"`
+	UserId         string             `json:"user_id" bson:"user_id,omitempty"`
+	Username       string             `json:"username" bson:"username,omitempty"`
+	OrganisationId string             `json:"organisationId" bson:"organisationId,omitempty"`
+	CreatedAt      int64              `json:"created_at" bson:"created_at,omitempty"`
+	UpdatedAt      int64              `json:"updated_at" bson:"updated_at,omitempty"`
 }
 
 // Input / Output types for repository operations

--- a/pkg/models/workflowrun.go
+++ b/pkg/models/workflowrun.go
@@ -22,12 +22,30 @@ import (
 //
 // The same shape travels every hop of the workflow tail:
 //
-//	analysis ──WorkflowRun{operation:"event"}──▶ engine
-//	engine   ──WorkflowRun{operation:<stage>, storage}──▶ stage worker
-//	worker   ──WorkflowRun{operation:<stage>, results}──▶ engine
+//	analysis ──WorkflowRun{operation:"event"}──────────────────▶ engine
+//	engine   ──WorkflowRun{operation:<stage>, storage}─────────▶ stage worker
+//	worker   ──WorkflowRun{operation:<stage>, payload|results}─▶ engine
 //
 // so each consumer reads and writes the one object instead of reconstructing
 // state from a generic bag.
+//
+// Integrator contract (engine ⇄ a custom stage worker) — the stable surface a
+// third-party stage codes against:
+//
+//   - A worker RECEIVES the engine→worker dispatch above: its Operation, the
+//     run identity (RunId, Key) and trace (TraceId), the curated User/Device
+//     context, the immutable start context (Inputs) and accumulated upstream
+//     outputs (Results), and the Storage credentials to fetch the media.
+//   - A worker RETURNS the same envelope it received — echo RunId, Key, TraceId
+//     and User so the engine can locate and scope the run — with Storage
+//     cleared and its result in exactly ONE channel. A delegated-ingest stage
+//     (its WorkflowStage declares an ingest Kind) sets Payload to its kind's
+//     typed body — a PostDetectionsRequest for kind "detection" (task
+//     "detection" or "pose"), a PostANPRRequest for kind "anpr" — which the
+//     engine persists through the shared ingest core and mirrors into Results.
+//     A self-persisting stage (no Kind) instead writes its own collection and
+//     returns just its routing values under Results[operation]. A worker never
+//     populates both.
 //
 // Tag discipline keeps the two representations from bleeding into each other:
 //   - `bson:"-"` marks WIRE-ONLY fields (transport role, curated projections,
@@ -43,7 +61,7 @@ type WorkflowRun struct {
 	//     carries the start context in Inputs (e.g. the classification result).
 	//   - any other value (e.g. "anpr"): either the engine dispatching that
 	//     stage to its worker (Storage populated), or the worker routing its
-	//     result back (Results populated). These never collide because the
+	//     result back (Payload or Results populated). These never collide because the
 	//     workflows queue only ever carries the "event" open and worker results —
 	//     a dispatch goes to the worker's own queue — so the engine never has to
 	//     disambiguate a dispatch from a result.
@@ -78,8 +96,12 @@ type WorkflowRun struct {
 	// RecordingTimestamp is the recording's start time (unix seconds), copied
 	// from the recording at hand-off time. It is denormalised onto any platform
 	// artifact the engine ingests (see Payload) so cleanup expires the artifact
-	// on the recording's retention clock rather than the post time. Persisted at
-	// open and also echoed on the wire so a worker round-trips it back.
+	// on the recording's retention clock rather than the post time. It is set on
+	// the analysis hand-off and persisted on the run at open; the engine then
+	// reads it from the run document when stamping an ingested artifact. It is
+	// therefore engine-internal — NOT sent on the engine→worker dispatch and not
+	// something a worker has to echo back, so it is not part of the stage
+	// contract.
 	RecordingTimestamp int64 `json:"recordingTimestamp,omitempty" bson:"recordingtimestamp,omitempty"`
 
 	// UserId scopes the run to an account (the organisation id). Persistence-only:
@@ -93,11 +115,12 @@ type WorkflowRun struct {
 	Start int64 `json:"-" bson:"start"`
 	End   int64 `json:"-" bson:"end,omitempty"`
 
-	// User is the curated, secret-free account context a run needs: the account
-	// id and organisation for logging/scoping and the account Storage block used
-	// to resolve a per-recording vault override. Copied (and scrubbed) from the
-	// analysis monitor stage — credential/secret fields never cross the boundary.
-	// Wire-only; the persisted scope is UserId.
+	// User is the curated, secret-free account context a run needs: the
+	// organisation that owns the recording (for logging/scoping) and the account
+	// Storage block used to resolve a per-recording vault override. Copied (and
+	// scrubbed) from the analysis monitor stage — credential/secret fields and the
+	// individual user id never cross the boundary. Wire-only; the persisted scope
+	// is UserId (which holds the organisation id).
 	User WorkflowUser `json:"user,omitempty" bson:"-"`
 
 	// Device identifies the recording the run derives from, with the few fields
@@ -133,7 +156,10 @@ type WorkflowRun struct {
 	//   - A delegated-ingest stage (its WorkflowStage declares an ingest Kind)
 	//     sets Payload on its result; the engine routes it through ingest.Ingest
 	//     into the stage's platform-owned collection and mirrors its decoded form
-	//     into Results so downstream conditions can branch on it.
+	//     into Results so downstream conditions can branch on it. The engine
+	//     targets the run's own recording (Key/User/Device), so a payload that
+	//     also carries its own recording reference (e.g. a PostDetectionsRequest
+	//     mediaKey/analysisId) has that reference ignored on the queue path.
 	//   - A self-persisting stage (no Kind) writes its own collection and returns
 	//     its routing values in Results instead; Payload is empty.
 	//
@@ -150,23 +176,39 @@ type WorkflowRun struct {
 	// persisted state.
 	Storage *WorkflowStorage `json:"storage,omitempty" bson:"-"`
 
-	// DispatchedOperations are the custom stages the engine has enqueued for this
+	// DispatchedOperations are the operation ids the engine has enqueued for this
 	// run — the always-stages seeded at open plus any conditional stages that
-	// matched. Persistence-only; written idempotently via $addToSet.
+	// matched. Every entry is a deployed stage's operation (only stages are ever
+	// dispatched), so here stage and operation coincide; the field is named by
+	// operation because the stored value is the operation id and to stay
+	// symmetric with ResolvedOperations. Persistence-only; written idempotently
+	// via $addToSet.
 	DispatchedOperations []string `json:"-" bson:"dispatchedoperations,omitempty"`
 
-	// ResolvedOperations are the upstream operations whose results the engine has
-	// observed (drives conditional dispatch and idempotency). Persistence-only.
+	// ResolvedOperations are the operation ids whose stage results the engine has
+	// observed (each worker hands its result back under its operation). With
+	// DispatchedOperations it drives finalization — the run ends once every
+	// dispatched operation is resolved — and idempotency.
+	//
+	// This is narrower than the set a need's gate checks: gate readiness is
+	// evaluated against the run's available operations — the keys of Inputs ∪
+	// Results, which also include the trigger analysis hands off (e.g. "classify")
+	// that seeds Inputs but never resolves as a stage and so never appears here.
+	// Persistence-only.
 	ResolvedOperations []string `json:"-" bson:"resolvedoperations,omitempty"`
 }
 
-// WorkflowUser is the secret-free projection of an account carried on a
-// WorkflowRun. It exposes only what the workflow tail consumes: identity for
-// logging/scoping and the account-level Storage block used to resolve a vault
-// override. Every credential/secret/billing field of the full User is
-// deliberately omitted so it can never reach the workflows queue or its logs.
+// WorkflowUser is the secret-free projection of the owning account carried on a
+// WorkflowRun. A run derives from a recording, which is owned by an
+// organisation (and device), not an individual user, so the scope is the
+// OrganisationId — the run document is keyed by (Key, OrganisationId) and every
+// ingested artifact is scoped to it. The individual user id is deliberately NOT
+// carried: it would imply a user↔recording link that does not exist and is not
+// needed by any stage. The account-level Storage block rides along only to
+// resolve a per-recording vault override. Every credential/secret/billing field
+// of the full User is omitted so it can never reach the workflows queue or its
+// logs.
 type WorkflowUser struct {
-	Id             string  `json:"id,omitempty"`
 	OrganisationId string  `json:"organisationId,omitempty"`
 	Storage        Storage `json:"storage,omitempty"`
 }

--- a/pkg/models/workflowrun.go
+++ b/pkg/models/workflowrun.go
@@ -1,0 +1,199 @@
+package models
+
+import (
+	"encoding/json"
+
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+// WorkflowRun is the single type the workflow subsystem uses for a run, in both
+// of its representations:
+//
+//   - the self-contained MESSAGE exchanged on the workflows queue and the
+//     per-stage queues (JSON), and
+//   - the persisted run DOCUMENT in the workflow_runs collection (BSON).
+//
+// It is deliberately NOT a PipelineEvent: the workflows tail is a separate
+// fan-out, so the message carries only the data a run needs — copied from the
+// upstream pipeline at hand-off time — rather than inheriting the whole pipeline
+// envelope. This gives an explicit, auditable contract for what a run sees and
+// what it persists, with the producer (analysis) in full control of what
+// crosses the boundary.
+//
+// The same shape travels every hop of the workflow tail:
+//
+//	analysis ──WorkflowRun{operation:"event"}──▶ engine
+//	engine   ──WorkflowRun{operation:<stage>, storage}──▶ stage worker
+//	worker   ──WorkflowRun{operation:<stage>, results}──▶ engine
+//
+// so each consumer reads and writes the one object instead of reconstructing
+// state from a generic bag.
+//
+// Tag discipline keeps the two representations from bleeding into each other:
+//   - `bson:"-"` marks WIRE-ONLY fields (transport role, curated projections,
+//     the credential-bearing Storage) so they NEVER persist to Mongo — most
+//     importantly Storage, so credentials can never land in run state.
+//   - `json:"-"` marks PERSISTENCE-ONLY fields (the run's stored identity and
+//     progress tiers) so they never appear on the queue contract.
+//   - Fields tagged for both (Key, TraceId, WorkflowId, WorkflowName) are the
+//     genuine overlap between message and document.
+type WorkflowRun struct {
+	// Operation marks the message's role on the workflows queue (wire-only):
+	//   - "event": a fresh run hand-off from analysis. It opens the run and
+	//     carries the start context in Inputs (e.g. the classification result).
+	//   - any other value (e.g. "anpr"): either the engine dispatching that
+	//     stage to its worker (Storage populated), or the worker routing its
+	//     result back (Results populated). These never collide because the
+	//     workflows queue only ever carries the "event" open and worker results —
+	//     a dispatch goes to the worker's own queue — so the engine never has to
+	//     disambiguate a dispatch from a result.
+	Operation string `json:"operation,omitempty" bson:"-"`
+
+	// RunId is the run's identifier on the wire (the hex of the document Id). It
+	// is empty on the analysis hand-off — the run is keyed by Key until the
+	// engine opens it — and set on every engine→worker dispatch. The persisted
+	// identity is Id, so RunId itself is wire-only.
+	RunId string `json:"runId,omitempty" bson:"-"`
+
+	// Id is the run document's Mongo identity. Persistence-only — on the wire the
+	// run is referenced by RunId (Id.Hex()).
+	Id primitive.ObjectID `json:"-" bson:"_id,omitempty"`
+
+	// WorkflowId is the id of the Workflow definition (models.Workflow) this run
+	// executes — the authored graph (nodes/edges/trigger) the run is an execution
+	// of, as opposed to the global stage registry. Forward-looking: it is set once
+	// the engine executes Workflow graphs; while the engine is driven by the flat
+	// stage registry it is empty.
+	WorkflowId string `json:"workflowId,omitempty" bson:"workflowid,omitempty"`
+
+	// WorkflowName is the human-readable name of that Workflow, carried so a
+	// dispatch/result is legible in worker context and logs without a lookup.
+	// Populated alongside WorkflowId.
+	WorkflowName string `json:"workflowName,omitempty" bson:"workflowname,omitempty"`
+
+	// Key is the media key the run is about: its natural identity, used to load
+	// or open the run document. Copied from the recording at hand-off time.
+	Key string `json:"key,omitempty" bson:"key"`
+
+	// RecordingTimestamp is the recording's start time (unix seconds), copied
+	// from the recording at hand-off time. It is denormalised onto any platform
+	// artifact the engine ingests (see Payload) so cleanup expires the artifact
+	// on the recording's retention clock rather than the post time. Persisted at
+	// open and also echoed on the wire so a worker round-trips it back.
+	RecordingTimestamp int64 `json:"recordingTimestamp,omitempty" bson:"recordingtimestamp,omitempty"`
+
+	// UserId scopes the run to an account (the organisation id). Persistence-only:
+	// on the wire the same identity travels in the richer User projection.
+	UserId string `json:"-" bson:"userid"`
+
+	// TraceId continues the distributed trace across the workflow tail.
+	TraceId string `json:"traceId,omitempty" bson:"traceid"`
+
+	// Start and End stamp the run's lifecycle (unix seconds). Persistence-only.
+	Start int64 `json:"-" bson:"start"`
+	End   int64 `json:"-" bson:"end,omitempty"`
+
+	// User is the curated, secret-free account context a run needs: the account
+	// id and organisation for logging/scoping and the account Storage block used
+	// to resolve a per-recording vault override. Copied (and scrubbed) from the
+	// analysis monitor stage — credential/secret fields never cross the boundary.
+	// Wire-only; the persisted scope is UserId.
+	User WorkflowUser `json:"user,omitempty" bson:"-"`
+
+	// Device identifies the recording the run derives from, with the few fields
+	// vault-override resolution and logging need (device key/name and where the
+	// media is stored/served from). Copied from the recording at hand-off time.
+	// Wire-only.
+	Device WorkflowDevice `json:"device,omitempty" bson:"-"`
+
+	// Inputs is the immutable start context the run opens with, keyed by the
+	// upstream operation that produced it (e.g. "classify" → the classification
+	// result). Conditions and stages read upstream context from here; it is set
+	// once by analysis and never mutated by the run. Persisted at open so a run
+	// reloaded mid-flight still sees its start context.
+	Inputs map[string]interface{} `json:"inputs,omitempty" bson:"inputs,omitempty"`
+
+	// Results is the run's accumulated stage outputs, keyed by operation. Each
+	// stage worker writes its result under its operation on the way back, and
+	// conditions / downstream stages read upstream outputs from here. It grows
+	// as the run progresses; the engine records each result into it. Together
+	// with Inputs it is the durable condition bag (Results wins on any overlap).
+	Results map[string]interface{} `json:"results,omitempty" bson:"results,omitempty"`
+
+	// Payload is the raw, typed result body a delegated-ingest stage hands back
+	// for the platform to persist — the single operation in Operation, in its
+	// kind's contract shape (e.g. a detection-run body). It is the channel the
+	// shared ingest core reads from, distinct from Results:
+	//
+	//   - Results is the multi-operation, decoded routing/state ledger the
+	//     condition matcher reads and the run persists.
+	//   - Payload is a single stage's raw typed bytes for one ingest hop.
+	//
+	// Lifecycle mirrors Storage and is one-directional (worker → engine):
+	//   - A delegated-ingest stage (its WorkflowStage declares an ingest Kind)
+	//     sets Payload on its result; the engine routes it through ingest.Ingest
+	//     into the stage's platform-owned collection and mirrors its decoded form
+	//     into Results so downstream conditions can branch on it.
+	//   - A self-persisting stage (no Kind) writes its own collection and returns
+	//     its routing values in Results instead; Payload is empty.
+	//
+	// `bson:"-"` is load-bearing: the raw body is ingested into its own
+	// collection, never duplicated into the run's persisted state. The engine
+	// never sets it on an outbound dispatch, so it never travels engine → worker.
+	Payload json.RawMessage `json:"payload,omitempty" bson:"-"`
+
+	// Storage carries the credentials a dispatched stage worker needs to fetch
+	// the media (global Kerberos Storage plus any resolved per-recording vault
+	// override). It is populated by the engine only on the engine→worker
+	// dispatch hop and is empty on the analysis hand-off and the worker→engine
+	// result. `bson:"-"` is load-bearing: credentials never sit in the run's
+	// persisted state.
+	Storage *WorkflowStorage `json:"storage,omitempty" bson:"-"`
+
+	// DispatchedOperations are the custom stages the engine has enqueued for this
+	// run — the always-stages seeded at open plus any conditional stages that
+	// matched. Persistence-only; written idempotently via $addToSet.
+	DispatchedOperations []string `json:"-" bson:"dispatchedoperations,omitempty"`
+
+	// ResolvedOperations are the upstream operations whose results the engine has
+	// observed (drives conditional dispatch and idempotency). Persistence-only.
+	ResolvedOperations []string `json:"-" bson:"resolvedoperations,omitempty"`
+}
+
+// WorkflowUser is the secret-free projection of an account carried on a
+// WorkflowRun. It exposes only what the workflow tail consumes: identity for
+// logging/scoping and the account-level Storage block used to resolve a vault
+// override. Every credential/secret/billing field of the full User is
+// deliberately omitted so it can never reach the workflows queue or its logs.
+type WorkflowUser struct {
+	Id             string  `json:"id,omitempty"`
+	OrganisationId string  `json:"organisationId,omitempty"`
+	Storage        Storage `json:"storage,omitempty"`
+}
+
+// WorkflowDevice is the projection of a recording's device carried on a
+// WorkflowRun. It holds the device key/name plus where the media is stored and
+// served from — exactly the inputs vault-override resolution and logging need,
+// without the rest of the Media/Device documents.
+type WorkflowDevice struct {
+	DeviceKey       string `json:"deviceKey,omitempty"`
+	DeviceName      string `json:"deviceName,omitempty"`
+	Provider        string `json:"provider,omitempty"`        // media VideoProvider: where the media is served from
+	StorageSolution string `json:"storageSolution,omitempty"` // media StorageSolution: where the media is stored
+}
+
+// WorkflowStorage carries the storage credentials a dispatched stage worker
+// uses to fetch the media. It pairs the global Kerberos Storage credentials
+// with an optional per-recording vault override (so derived artifacts land on
+// the same backend as the recording). It only ever travels on the engine→worker
+// dispatch hop.
+type WorkflowStorage struct {
+	Uri       string `json:"uri,omitempty"`
+	AccessKey string `json:"accessKey,omitempty"`
+	Secret    string `json:"secret,omitempty"`
+
+	VaultOverrideUri       string `json:"vaultOverrideUri,omitempty"`
+	VaultOverrideAccessKey string `json:"vaultOverrideAccessKey,omitempty"`
+	VaultOverrideSecret    string `json:"vaultOverrideSecret,omitempty"`
+	VaultOverrideProvider  string `json:"vaultOverrideProvider,omitempty"`
+}

--- a/pkg/models/workflowstage.go
+++ b/pkg/models/workflowstage.go
@@ -9,8 +9,9 @@ import "go.mongodb.org/mongo-driver/bson/primitive"
 // DispatchAlways.
 //
 //	always      — enqueued at workflow start, unconditionally.
-//	conditional — enqueued only when one of its upstream dependencies resolves
-//	              and that dependency's Condition matches the upstream result.
+//	conditional — held at start and enqueued only when its Needs are satisfied
+//	              against the run: each need's gate operation is available and
+//	              its Condition matches the run (see Needs and StageDependency).
 type Dispatch string
 
 const (
@@ -68,7 +69,7 @@ const (
 //     results.anpr.plates).
 //   - device.<field>        — the recording source (deviceKey, deviceName,
 //     provider, storageSolution).
-//   - user.<field>          — the owning account (id, organisationId only).
+//   - user.<field>          — the owning account (organisationId only).
 //   - operation, runId, key, traceId — the run's top-level identity scalars.
 //
 // Credentials are deliberately unreachable: the run's Storage block and
@@ -84,20 +85,27 @@ type StageCondition struct {
 
 // StageDependency is one trigger a conditional stage waits on, paired with the
 // predicate that must hold for the stage to fire. It mirrors a single incoming
-// workflow edge: Operation is the edge's source stage (the readiness gate), and
-// Condition is the edge's predicate (nil for an unconditional dependency).
+// workflow edge: Operation is the edge's source operation (the readiness gate),
+// and Condition is the edge's predicate (nil for an unconditional dependency).
 //
-// Operation and Condition are now decoupled: Operation is purely a readiness
-// gate ("don't evaluate this need until that operation's data is present on the
+// Operation and Condition are decoupled: Operation is purely a readiness gate
+// ("don't evaluate this need until that operation's data is present on the
 // run"), while Condition is an absolute predicate over the whole run root (see
 // StageCondition) — it need not reference Operation's result at all. A need may
 // gate on classify yet match device.deviceKey, for example.
+//
+// Note Operation is an OPERATION id, not necessarily a deployed STAGE: gate
+// readiness is checked against the run's available operations (the keys of
+// Inputs ∪ Results), which include the analysis trigger ("classify") that is not
+// a stage. See WorkflowStage.Operation for the stage/operation distinction.
 type StageDependency struct {
-	// Operation is the upstream stage whose presence gates this need. It must be
-	// in the run's resolved/available operations before the need's Condition is
-	// evaluated. Empty means the need is ungated: it is a check on the run root
-	// itself (device/user/identity, or an input present from open), evaluated as
-	// soon as the run opens with nothing to wait for.
+	// Operation is the id of the operation whose presence gates this need: it must
+	// be available on the run — present in Inputs or Results — before the need's
+	// Condition is evaluated. It is an operation id, not necessarily a deployed
+	// stage: the most common gate, "classify", is the analysis trigger (it arrives
+	// in Inputs at open), not a stage. Empty means the need is ungated: a check on
+	// the run root itself (device/user/identity, or an input present from open),
+	// evaluated as soon as the run opens with nothing to wait for.
 	Operation string `json:"operation,omitempty" bson:"operation,omitempty"`
 	// Condition is the predicate evaluated against the run root. Nil means the
 	// need matches as soon as its gate (if any) is satisfied.
@@ -199,8 +207,21 @@ type WorkflowStage struct {
 	// --- Routing ---
 
 	// Operation uniquely identifies the stage and binds its queue, dispatch and
-	// resolution. It is the key that workflow nodes reference. Two stages may
-	// never share an operation.
+	// resolution. It is the key workflow nodes reference, and the key under which
+	// the stage's result is filed in a run's Inputs/Results. Two stages may never
+	// share an operation.
+	//
+	// Stage vs. operation — they are not synonyms:
+	//   - a STAGE is this definition: a deployed worker with a queue and a
+	//     dispatch rule.
+	//   - an OPERATION is the id string. It names this stage, and it is also the
+	//     key results are filed under on a run.
+	// Every deployed stage has an operation, but a run's operation keyspace is
+	// wider than its stages: it also includes the trigger analysis hands off
+	// (e.g. "classify"), which seeds Inputs and can gate a need or be read by a
+	// condition, yet is not itself a deployed stage. That is why routing —
+	// Needs/gates, conditions, and the run's dispatched/resolved tiers — is keyed
+	// by operation (the wider id space), while deployment talks in stages.
 	Operation string `json:"operation" bson:"operation"`
 	// Dispatch is when the stage runs: DispatchAlways or DispatchConditional (the
 	// closed Dispatch enum). Empty defaults to DispatchAlways. For a user

--- a/pkg/models/workflowstage.go
+++ b/pkg/models/workflowstage.go
@@ -18,6 +18,27 @@ const (
 	DispatchConditional Dispatch = "conditional"
 )
 
+// NeedsMode is the closed enum describing how a conditional stage's multiple
+// Needs combine into a single dispatch decision. It is named (not a boolean) so
+// further join modes can be added without a schema change, and only meaningful
+// when Dispatch is DispatchConditional and the stage has more than one need. An
+// empty NeedsMode defaults to NeedsModeAny.
+//
+//	any — fire as soon as one of the stage's needs is satisfied: its gate
+//	      operation is available on the run (or empty/ungated) and its condition
+//	      matches the run root (fan-in as OR). This is the back-compatible
+//	      default.
+//	all — fire only once every need is satisfied: each need's gate operation is
+//	      available and each need's condition matches the run root (fan-in as
+//	      AND / a join). A need whose gate operation is not yet available blocks
+//	      the stage.
+type NeedsMode string
+
+const (
+	NeedsModeAny NeedsMode = "any"
+	NeedsModeAll NeedsMode = "all"
+)
+
 // ConditionOp is the closed enum of comparison operators a StageCondition may
 // use. Named so the allowed operators are part of the type instead of a comment.
 type ConditionOp string
@@ -34,24 +55,52 @@ const (
 	ConditionOpLte      ConditionOp = "lte"      // less than or equal (numeric)
 )
 
-// StageCondition is a structured predicate evaluated against an upstream
-// operation's returned result. No free-form expressions are allowed: a
-// condition is a single (path, op, value) triple.
+// StageCondition is a structured predicate evaluated against the workflow run.
+// No free-form expressions are allowed: a condition is a single (path, op,
+// value) triple.
+//
+// Path is an absolute, dot-separated lookup rooted at the run object itself, not
+// at any single operation's result. The reachable roots are:
+//
+//   - inputs.<op>.<field>   — the run's immutable start context (e.g.
+//     inputs.classify.properties).
+//   - results.<op>.<field>  — an upstream stage's accumulated output (e.g.
+//     results.anpr.plates).
+//   - device.<field>        — the recording source (deviceKey, deviceName,
+//     provider, storageSolution).
+//   - user.<field>          — the owning account (id, organisationId only).
+//   - operation, runId, key, traceId — the run's top-level identity scalars.
+//
+// Credentials are deliberately unreachable: the run's Storage block and
+// user.storage are excluded from the matchable root, so a condition can never
+// match a secret. The lookup walks string-keyed maps only — it cannot index
+// into arrays (no results.anpr.items.0.x), so an array/scalar field is matchable
+// only at its own segment.
 type StageCondition struct {
-	Path  string      `json:"path" bson:"path"`   // dot-path into the upstream op's result
+	Path  string      `json:"path" bson:"path"`   // absolute dot-path into the run root (see type doc)
 	Op    ConditionOp `json:"op" bson:"op"`       // see the ConditionOp consts
 	Value any         `json:"value" bson:"value"` // comparison operand (unused for ConditionOpExists)
 }
 
-// StageDependency is one upstream a conditional stage waits on, paired with the
-// predicate that must match that upstream's result. It mirrors a single
-// incoming workflow edge: Operation is the edge's source stage, and Condition
-// is the edge's condition (nil for an unconditional dependency).
+// StageDependency is one trigger a conditional stage waits on, paired with the
+// predicate that must hold for the stage to fire. It mirrors a single incoming
+// workflow edge: Operation is the edge's source stage (the readiness gate), and
+// Condition is the edge's predicate (nil for an unconditional dependency).
+//
+// Operation and Condition are now decoupled: Operation is purely a readiness
+// gate ("don't evaluate this need until that operation's data is present on the
+// run"), while Condition is an absolute predicate over the whole run root (see
+// StageCondition) — it need not reference Operation's result at all. A need may
+// gate on classify yet match device.deviceKey, for example.
 type StageDependency struct {
-	// Operation is the upstream stage this dependency waits on.
-	Operation string `json:"operation" bson:"operation"`
-	// Condition is the predicate evaluated against the upstream's result. Nil
-	// means the dependency matches as soon as the upstream resolves.
+	// Operation is the upstream stage whose presence gates this need. It must be
+	// in the run's resolved/available operations before the need's Condition is
+	// evaluated. Empty means the need is ungated: it is a check on the run root
+	// itself (device/user/identity, or an input present from open), evaluated as
+	// soon as the run opens with nothing to wait for.
+	Operation string `json:"operation,omitempty" bson:"operation,omitempty"`
+	// Condition is the predicate evaluated against the run root. Nil means the
+	// need matches as soon as its gate (if any) is satisfied.
 	Condition *StageCondition `json:"condition,omitempty" bson:"condition,omitempty"`
 }
 
@@ -158,14 +207,24 @@ type WorkflowStage struct {
 	// workflow it is derived from the graph's edges (conditional when the node has
 	// at least one incoming edge); see the Routing note above.
 	Dispatch Dispatch `json:"dispatch,omitempty" bson:"dispatch,omitempty"`
-	// Needs lists the upstream dependencies of a conditional stage — its fan-in.
-	// It is the compiled, runtime-authoritative projection of the workflow's
-	// incoming edges (one entry per edge), not an independently editable field. At
-	// least one entry is required when Dispatch is DispatchConditional; ignored
-	// otherwise. The runtime re-evaluates the stage whenever any listed upstream
-	// resolves, and the stage fires for the first dependency whose Condition
-	// matches that upstream's result (a nil Condition matches unconditionally).
+	// Needs lists the dependencies of a conditional stage — its fan-in. It is the
+	// compiled, runtime-authoritative projection of the workflow's incoming edges
+	// (one entry per edge), not an independently editable field. At least one
+	// entry is required when Dispatch is DispatchConditional; ignored otherwise.
+	// The runtime re-evaluates the stage against the run root whenever the run
+	// progresses; each need's Operation gates when its Condition may be read (an
+	// empty Operation is ungated, evaluated at open) and the stage fires for the
+	// first need whose Condition matches (a nil Condition matches unconditionally).
 	Needs []StageDependency `json:"needs,omitempty" bson:"needs,omitempty"`
+
+	// NeedsMode controls how multiple Needs combine into a dispatch decision:
+	// NeedsModeAny (the default) fires the stage as soon as one need is satisfied
+	// (its gate operation available and its condition matching); NeedsModeAll
+	// fires the stage only once every need is satisfied (a join). It is
+	// meaningful only when Dispatch is DispatchConditional and there is more than
+	// one need; with a single need both modes behave identically. Empty defaults
+	// to NeedsModeAny.
+	NeedsMode NeedsMode `json:"needsMode,omitempty" bson:"needsMode,omitempty"`
 
 	// --- Contract ---
 
@@ -178,6 +237,17 @@ type WorkflowStage struct {
 	// a single implicit default port.
 	Inputs  []StagePort `json:"inputs,omitempty" bson:"inputs,omitempty"`
 	Outputs []StagePort `json:"outputs,omitempty" bson:"outputs,omitempty"`
+
+	// Kind names the ingest handler the platform routes this stage's typed result
+	// through (e.g. "detection"). When set, the stage is delegated-ingest: its
+	// worker hands the typed result back in WorkflowRun.Payload and the engine
+	// calls the shared ingest core to persist it into the kind's platform-owned
+	// collection (and mirrors the decoded form into the run's Results for
+	// routing). When empty the stage is self-persisting: its worker writes its
+	// own collection and the engine only records the result it returns in
+	// Results. A Kind with no handler registered in the ingest core is treated as
+	// self-persist — the result is recorded, not ingested.
+	Kind string `json:"kind,omitempty" bson:"kind,omitempty"`
 
 	// --- Deployment ---
 


### PR DESCRIPTION
## Description

### Motivation & Impact

This change introduces first‑class **ANPR (Automatic Number Plate Recognition)** support to the ingest and workflow pipeline.

Until now, the ingest system only had a generic “detections” contract, which does not accurately model ANPR results. Plate reads are fundamentally different from bounding‑box tracks: they are text‑centric, may have multiple candidates, and may or may not include geometry. Reusing detections would blur these semantics and make validation, storage, and downstream usage error‑prone.

### Why this improves the project

- **Clear, typed contract for ANPR**  
  Adds a dedicated API payload (`PostANPRRequest`) and ingest handler that precisely represent ANPR data instead of overloading detections.

- **Safer ingestion with partial tolerance**  
  Valid plates are stored even if others are malformed, preserving provenance while surfacing detailed rejection reasons and warnings.

- **Idempotent, scalable storage**  
  ANPR runs are stored in their own collection and upserted by `(recording key, runId)`, matching existing ingest guarantees.

- **Better product integration**  
  Pipeline‑originated ANPR runs automatically generate user‑visible markers on the timeline, while API pushes remain storage‑only by policy.

- **Workflow alignment**  
  Documentation clarifies how workflow stages return detection‑like payloads, and ANPR cleanly fits into the same delegated‑ingest model without abusing existing APIs.

Overall, this lays a clean foundation for ANPR as a first‑class feature: clearer contracts, safer ingest, and better downstream UX, without breaking existing detection workflows.