### PR TITLE
add signedurl

### DIFF
--- a/pkg/models/workflowrun.go
+++ b/pkg/models/workflowrun.go
@@ -50,8 +50,9 @@ import (
 //
 // Tag discipline keeps the two representations from bleeding into each other:
 //   - `bson:"-"` marks WIRE-ONLY fields (transport role, curated projections,
-//     the credential-bearing Storage) so they NEVER persist to Mongo — most
-//     importantly Storage, so credentials can never land in run state.
+//     the credential-bearing Storage and SignedURL) so they NEVER persist to
+//     Mongo — most importantly the credential carriers, so secrets can never
+//     land in run state.
 //   - `json:"-"` marks PERSISTENCE-ONLY fields (the run's stored identity and
 //     progress tiers) so they never appear on the queue contract.
 //   - Fields tagged for both (Key, TraceId, WorkflowId, WorkflowName) are the
@@ -179,6 +180,17 @@ type WorkflowRun struct {
 	// result. `bson:"-"` is load-bearing: credentials never sit in the run's
 	// persisted state.
 	Storage *WorkflowStorage `json:"storage,omitempty" bson:"-"`
+
+	// SignedURL is a vault-signed, short-lived URL (HMAC signature + TTL) a
+	// dispatched stage worker can use to fetch the run's media directly, instead
+	// of constructing the request from the raw Storage credentials. It is the
+	// signed URL the upstream pipeline already holds for the recording (the same
+	// one carried on PipelinePayload.SignedURL), copied onto the run at the
+	// analysis hand-off and carried on the engine→worker dispatch alongside
+	// Storage. `bson:"-"` is load-bearing: a signed URL is credential-equivalent
+	// and short-lived, so — like Storage — it is wire-only and never lands in the
+	// run's persisted state; a stage dispatched after a reload fetches via Storage.
+	SignedURL string `json:"signedUrl,omitempty" bson:"-"`
 
 	// DispatchedOperations are the operation ids the engine has enqueued for this
 	// run — the always-stages seeded at open plus any conditional stages that


### PR DESCRIPTION
## Description

### Motivation

Stage workers currently rely on raw `Storage` credentials to fetch run media, even when a short‑lived, vault‑signed URL already exists upstream. This forces unnecessary credential handling and increases the risk surface around secret usage.

### Why this improves the project

This change adds a `SignedURL` field to `WorkflowRun` as a **wire‑only** attribute, allowing workers to fetch media directly via a pre‑signed, time‑limited URL instead of reconstructing requests from storage credentials.  
By explicitly marking `SignedURL` as non‑persistent (`bson:"-"`), we preserve the project’s security guarantees: no credential‑equivalent data is ever stored in Mongo.

The result is:
- Reduced exposure and handling of long‑lived credentials
- Clearer separation between transport‑only and persisted state
- Better alignment with the existing pipeline contract and security model

Overall, this makes media access safer, simpler, and more consistent across the system.