### PR TITLE
feat(marker): add detection metadata fields to MarkerMetadata

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/stretchr/testify v1.11.1 // indirect
-	golang.org/x/crypto v0.49.0 // indirect
-	golang.org/x/sys v0.42.0 // indirect
-	golang.org/x/text v0.35.0 // indirect
+	golang.org/x/crypto v0.51.0 // indirect
+	golang.org/x/sys v0.44.0 // indirect
+	golang.org/x/text v0.38.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -20,11 +20,11 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 go.mongodb.org/mongo-driver v1.17.9 h1:IexDdCuuNJ3BHrELgBlyaH9p60JXAvdzWR128q+U5tU=
 go.mongodb.org/mongo-driver v1.17.9/go.mod h1:LlOhpH5NUEfhxcAwG0UEkMqwYcc4JU18gtCdGudk/tQ=
-golang.org/x/crypto v0.49.0 h1:+Ng2ULVvLHnJ/ZFEq4KdcDd/cfjrrjjNSXNzxg0Y4U4=
-golang.org/x/crypto v0.49.0/go.mod h1:ErX4dUh2UM+CFYiXZRTcMpEcN8b/1gxEuv3nODoYtCA=
-golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
-golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
-golang.org/x/text v0.35.0 h1:JOVx6vVDFokkpaq1AEptVzLTpDe9KGpj5tR4/X+ybL8=
-golang.org/x/text v0.35.0/go.mod h1:khi/HExzZJ2pGnjenulevKNX1W67CUy0AsXcNubPGCA=
+golang.org/x/crypto v0.51.0 h1:IBPXwPfKxY7cWQZ38ZCIRPI50YLeevDLlLnyC5wRGTI=
+golang.org/x/crypto v0.51.0/go.mod h1:8AdwkbraGNABw2kOX6YFPs3WM22XqI4EXEd8g+x7Oc8=
+golang.org/x/sys v0.44.0 h1:ildZl3J4uzeKP07r2F++Op7E9B29JRUy+a27EibtBTQ=
+golang.org/x/sys v0.44.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/text v0.38.0 h1:sXmwo9DwP3OK9EZ7PqAdaooSGozfl/3a6/xJcbzPRhE=
+golang.org/x/text v0.38.0/go.mod h1:YXZt3QhHUKYT53r2lLKFIVi6Ao1jdzrTR/KQ09qyxF4=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/models/marker.go
+++ b/pkg/models/marker.go
@@ -47,6 +47,43 @@ func (m *Marker) Validate() error {
 
 type MarkerMetadata struct {
 	Comments *Comment `json:"comments,omitempty" bson:"comments,omitempty"` // Additional comments or description of the marker
+
+	// Confidence is the certainty of the detection that produced this marker, in the
+	// range [0,1] (e.g. an ANPR plate-read or object-detection score). A nil pointer
+	// means no confidence was reported; this keeps the value optional and lets a
+	// genuine 0 be distinguished from "unset".
+	Confidence *float64 `json:"confidence,omitempty" bson:"confidence,omitempty" example:"0.92"`
+
+	// Source identifies the pipeline that produced this marker (e.g. "anpr",
+	// "loitering", "dominantcolors"). This is provenance, distinct from the
+	// user-facing Categories on the marker.
+	Source string `json:"source,omitempty" bson:"source,omitempty" example:"anpr"`
+
+	// Engine identifies the concrete backend used within the pipeline
+	// (e.g. "fast-onnx", "tesseract", "http").
+	Engine string `json:"engine,omitempty" bson:"engine,omitempty" example:"fast-onnx"`
+
+	// ModelVersion records the version of the model that produced the detection,
+	// so detections can be correlated with model changes after the fact.
+	ModelVersion string `json:"modelVersion,omitempty" bson:"modelVersion,omitempty" example:"v1.4.0"`
+
+	// BoundingBox is the normalized [0,1] region of the detection within the frame,
+	// suitable for drawing overlays. Nil when no spatial information is available.
+	BoundingBox *MarkerBox `json:"boundingBox,omitempty" bson:"boundingBox,omitempty"`
+
+	// Raw is an escape hatch for pipeline-specific metadata that does not warrant a
+	// first-class field. Values here are not indexed or validated; promote anything
+	// you need to query into a typed field instead.
+	Raw map[string]any `json:"raw,omitempty" bson:"raw,omitempty"`
+}
+
+// MarkerBox is a normalized bounding box in the range [0,1], where (X, Y) is the
+// top-left corner and Width/Height are relative to the frame dimensions.
+type MarkerBox struct {
+	X      float64 `json:"x" bson:"x" example:"0.12"`           // Left edge, fraction of frame width
+	Y      float64 `json:"y" bson:"y" example:"0.34"`           // Top edge, fraction of frame height
+	Width  float64 `json:"width" bson:"width" example:"0.20"`   // Box width, fraction of frame width
+	Height float64 `json:"height" bson:"height" example:"0.10"` // Box height, fraction of frame height
 }
 
 type MarkerAtRuntimeMetadata struct {


### PR DESCRIPTION
## Description

This change extends `MarkerMetadata` with structured detection metadata so markers can carry richer provenance and inference details produced by detection pipelines.

The new fields add support for:
- Detection confidence scores
- Pipeline and engine identification
- Model version tracking
- Normalized bounding box coordinates
- Flexible pipeline-specific raw metadata

This improves the project by making markers significantly more useful for downstream consumers, analytics, debugging, and visualization workflows. Detection results can now be traced back to the exact pipeline and model that produced them, which is critical for auditing, tuning, and comparing model behavior over time.

Adding normalized bounding box support also enables UI overlays and spatial analysis without requiring custom extensions per detector.

The design keeps the schema backward-compatible and flexible:
- Optional pointer fields distinguish unset values from valid zero values
- `Raw` metadata provides an extensibility path without forcing schema churn
- Typed first-class fields preserve consistency for commonly queried metadata

The dependency updates in `golang.org/x/*` also bring the project onto newer supported library versions.