### PR TITLE
feat(workflow): manual/automatic triggers + run identity

### DIFF
--- a/pkg/models/workflow.go
+++ b/pkg/models/workflow.go
@@ -1,6 +1,10 @@
 package models
 
-import "go.mongodb.org/mongo-driver/bson/primitive"
+import (
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
 
 // WorkflowNode is a single stage instance placed on the workflow canvas. Every
 // node is an instance of a catalog stage: StageRef holds the referenced stage's
@@ -69,11 +73,11 @@ type WorkflowTriggerType string
 
 const (
 	// WorkflowTriggerAutomatic fires for every matching recording without user
-	// action. Automatic triggers honour Selection and the time window.
+	// action. Automatic triggers honour Devices and the weekly schedule.
 	WorkflowTriggerAutomatic WorkflowTriggerType = "automatic"
 	// WorkflowTriggerManual is user-launched from a surface against an explicit
-	// media selection. Manual triggers ignore Selection / the time window and
-	// instead advertise where they can be launched from via Surfaces.
+	// media selection. Manual triggers ignore Devices / the schedule and instead
+	// advertise where they can be launched from via Surfaces.
 	WorkflowTriggerManual WorkflowTriggerType = "manual"
 )
 
@@ -92,23 +96,31 @@ const (
 )
 
 // WorkflowTrigger defines what activates a workflow. Type selects the activation
-// mode; the remaining fields are mode-specific. For automatic triggers,
-// Selection/StartAt/EndAt/Weekdays scope which recordings and times the workflow
-// is eligible for (an empty automatic trigger leaves it eligible at all times for
-// everything routed to it). For manual triggers those scheduling fields are
-// ignored and Surfaces lists the UI surfaces the workflow can be launched from.
+// mode; the remaining fields are mode-specific. For automatic triggers, Devices
+// and WeeklySchedule scope which recordings and times the workflow is eligible
+// for (an empty automatic trigger leaves it eligible at all times for everything
+// routed to it). For manual triggers those scoping fields are ignored and
+// Surfaces lists the UI surfaces the workflow can be launched from.
+//
+// Devices and WeeklySchedule deliberately reuse the same shapes the alert/
+// videowall schedules use (DeviceKey, WeeklySchedule/DayTimeRange), so the same
+// device pickers and weekly-schedule editors — and the same weekday convention
+// (time.Weekday: 0=Sunday) and per-schedule IANA Timezone — apply here.
 type WorkflowTrigger struct {
 	// Type is the activation mode. An empty Type is treated as
 	// WorkflowTriggerAutomatic for backwards compatibility with triggers authored
 	// before manual triggers existed.
 	Type WorkflowTriggerType `json:"type,omitempty" bson:"type,omitempty"`
-	// Selection is the set of devices/streams the workflow applies to (automatic).
-	Selection string `json:"selection,omitempty" bson:"selection,omitempty"`
-	// StartAt and EndAt bound a daily time window, e.g. "08:00"/"18:00" (automatic).
-	StartAt string `json:"startAt,omitempty" bson:"startAt,omitempty"`
-	EndAt   string `json:"endAt,omitempty" bson:"endAt,omitempty"`
-	// Weekdays restricts the workflow to the listed days of week (automatic).
-	Weekdays []int `json:"weekdays,omitempty" bson:"weekdays,omitempty"`
+	// Devices restricts the automatic trigger to recordings from the listed
+	// devices, matched by DeviceKey.Key. An empty list means every device is
+	// eligible. Mirrors the alert device selection (see CustomAlert.DevicesList).
+	Devices []DeviceKey `json:"devices,omitempty" bson:"devices,omitempty"`
+	// WeeklySchedule bounds the automatic trigger to recurring weekly windows,
+	// each with its own day, time segments and IANA Timezone. An empty schedule
+	// means any time is eligible. Reuses the alert weekly-schedule shape so the
+	// same editor and evaluation semantics apply. The Timezone on each entry is
+	// the user's timezone captured when the schedule was authored.
+	WeeklySchedule []*WeeklySchedule `json:"weeklySchedule,omitempty" bson:"weeklySchedule,omitempty"`
 	// Surfaces lists the UI surfaces a manual trigger can be launched from
 	// (manual). Ignored for automatic triggers.
 	Surfaces []WorkflowTriggerSurface `json:"surfaces,omitempty" bson:"surfaces,omitempty"`
@@ -131,6 +143,49 @@ func (t WorkflowTrigger) HasSurface(surface WorkflowTriggerSurface) bool {
 		}
 	}
 	return false
+}
+
+// MatchesDevice reports whether a recording from deviceKey is in scope for this
+// automatic trigger. An empty Devices list matches every device; otherwise the
+// key must appear in the list (compared against DeviceKey.Key, like a stage's
+// device.deviceKey need).
+func (t WorkflowTrigger) MatchesDevice(deviceKey string) bool {
+	if len(t.Devices) == 0 {
+		return true
+	}
+	for _, d := range t.Devices {
+		if d.Key == deviceKey {
+			return true
+		}
+	}
+	return false
+}
+
+// IsScheduledAt reports whether at falls within this automatic trigger's weekly
+// schedule. An empty schedule matches any time; otherwise at must fall within an
+// enabled weekly segment. Each schedule entry is evaluated in its own IANA
+// Timezone (the user's timezone captured at authoring time), so at may be any
+// absolute instant — typically the recording timestamp.
+func (t WorkflowTrigger) IsScheduledAt(at time.Time) bool {
+	if len(t.WeeklySchedule) == 0 {
+		return true
+	}
+	for _, ws := range t.WeeklySchedule {
+		if ws.IsActiveAt(at) {
+			return true
+		}
+	}
+	return false
+}
+
+// Matches reports whether a recording from deviceKey at instant at satisfies this
+// automatic trigger's scope (device selection AND weekly schedule). It is the
+// single source of truth for the automatic activation gate, evaluated by the
+// producer before a WorkflowRun is minted. It is pure: the caller resolves the
+// recording's device key and timestamp and passes them in. Manual triggers do
+// not use this predicate — they are gated by surface, not by device/time.
+func (t WorkflowTrigger) Matches(deviceKey string, at time.Time) bool {
+	return t.MatchesDevice(deviceKey) && t.IsScheduledAt(at)
 }
 
 // Workflow is a user-defined automation graph composed of stage-instance nodes

--- a/pkg/models/workflow.go
+++ b/pkg/models/workflow.go
@@ -59,35 +59,134 @@ type WorkflowEdge struct {
 	Condition *StageCondition `json:"condition,omitempty" bson:"condition,omitempty"`
 }
 
-// WorkflowTrigger defines what activates a workflow: the device/stream
-// selection it applies to and an optional recurring time window. An empty
-// trigger leaves the workflow eligible at all times for everything routed to it.
+// WorkflowTriggerType is how a trigger activates its workflow. Automatic
+// triggers fire on their own for every matching recording (pipeline-teed by
+// hub-pipeline-analysis); manual triggers are launched on demand by a user from
+// a UI surface (see Surfaces) against an explicit selection of media. Both kinds
+// converge on the same workflows queue, engine and stages — only the run origin
+// differs (see WorkflowRun.Origin).
+type WorkflowTriggerType string
+
+const (
+	// WorkflowTriggerAutomatic fires for every matching recording without user
+	// action. Automatic triggers honour Selection and the time window.
+	WorkflowTriggerAutomatic WorkflowTriggerType = "automatic"
+	// WorkflowTriggerManual is user-launched from a surface against an explicit
+	// media selection. Manual triggers ignore Selection / the time window and
+	// instead advertise where they can be launched from via Surfaces.
+	WorkflowTriggerManual WorkflowTriggerType = "manual"
+)
+
+// WorkflowTriggerSurface is a place in the product a manual trigger can be
+// launched from. It lets a workflow opt in to (for example) a case's "Run
+// workflow" control purely as data, so surfaces list the workflows that apply to
+// them without any hard-coded workflow ids.
+type WorkflowTriggerSurface string
+
+const (
+	// WorkflowSurfaceCase exposes a manual trigger on a case/task, where it runs
+	// against the media the user selected in that case.
+	WorkflowSurfaceCase WorkflowTriggerSurface = "case"
+	// WorkflowSurfaceMedia exposes a manual trigger on an individual media item.
+	WorkflowSurfaceMedia WorkflowTriggerSurface = "media"
+)
+
+// WorkflowTrigger defines what activates a workflow. Type selects the activation
+// mode; the remaining fields are mode-specific. For automatic triggers,
+// Selection/StartAt/EndAt/Weekdays scope which recordings and times the workflow
+// is eligible for (an empty automatic trigger leaves it eligible at all times for
+// everything routed to it). For manual triggers those scheduling fields are
+// ignored and Surfaces lists the UI surfaces the workflow can be launched from.
 type WorkflowTrigger struct {
-	// Selection is the set of devices/streams the workflow applies to.
+	// Type is the activation mode. An empty Type is treated as
+	// WorkflowTriggerAutomatic for backwards compatibility with triggers authored
+	// before manual triggers existed.
+	Type WorkflowTriggerType `json:"type,omitempty" bson:"type,omitempty"`
+	// Selection is the set of devices/streams the workflow applies to (automatic).
 	Selection string `json:"selection,omitempty" bson:"selection,omitempty"`
-	// StartAt and EndAt bound a daily time window (e.g. "08:00"/"18:00").
+	// StartAt and EndAt bound a daily time window, e.g. "08:00"/"18:00" (automatic).
 	StartAt string `json:"startAt,omitempty" bson:"startAt,omitempty"`
 	EndAt   string `json:"endAt,omitempty" bson:"endAt,omitempty"`
-	// Weekdays restricts the workflow to the listed days of week.
+	// Weekdays restricts the workflow to the listed days of week (automatic).
 	Weekdays []int `json:"weekdays,omitempty" bson:"weekdays,omitempty"`
+	// Surfaces lists the UI surfaces a manual trigger can be launched from
+	// (manual). Ignored for automatic triggers.
+	Surfaces []WorkflowTriggerSurface `json:"surfaces,omitempty" bson:"surfaces,omitempty"`
+}
+
+// EffectiveType returns the trigger's activation mode, defaulting an empty Type
+// to WorkflowTriggerAutomatic so legacy triggers keep their original behaviour.
+func (t WorkflowTrigger) EffectiveType() WorkflowTriggerType {
+	if t.Type == "" {
+		return WorkflowTriggerAutomatic
+	}
+	return t.Type
+}
+
+// HasSurface reports whether this (manual) trigger is launchable from surface.
+func (t WorkflowTrigger) HasSurface(surface WorkflowTriggerSurface) bool {
+	for _, s := range t.Surfaces {
+		if s == surface {
+			return true
+		}
+	}
+	return false
 }
 
 // Workflow is a user-defined automation graph composed of stage-instance nodes
-// and the edges that route between them. Trigger says what activates it; the
+// and the edges that route between them. Triggers say what activates it (a
+// workflow may have several — e.g. an automatic trigger and a manual one); the
 // nodes/edges say what runs.
 type Workflow struct {
-	Id             primitive.ObjectID `json:"id" bson:"_id,omitempty"`
-	Name           string             `json:"name" bson:"name,omitempty"`
-	Description    string             `json:"description" bson:"description,omitempty"`
-	Enabled        bool               `json:"enabled" bson:"enabled"`
-	Trigger        *WorkflowTrigger   `json:"trigger,omitempty" bson:"trigger,omitempty"`
-	Nodes          []WorkflowNode     `json:"nodes" bson:"nodes"`
-	Edges          []WorkflowEdge     `json:"edges" bson:"edges"`
-	UserId         string             `json:"user_id" bson:"user_id,omitempty"`
-	Username       string             `json:"username" bson:"username,omitempty"`
-	OrganisationId string             `json:"organisation_id" bson:"organisation_id,omitempty"`
-	CreatedAt      int64              `json:"created_at" bson:"created_at,omitempty"`
-	UpdatedAt      int64              `json:"updated_at" bson:"updated_at,omitempty"`
+	Id          primitive.ObjectID `json:"id" bson:"_id,omitempty"`
+	Name        string             `json:"name" bson:"name,omitempty"`
+	Description string             `json:"description" bson:"description,omitempty"`
+	Enabled     bool               `json:"enabled" bson:"enabled"`
+	// Triggers is the set of activation modes for this workflow. A workflow may
+	// carry both an automatic and a manual trigger so it runs on its own for
+	// matching recordings and can also be launched on demand from a surface.
+	Triggers []WorkflowTrigger `json:"triggers,omitempty" bson:"triggers,omitempty"`
+	// Trigger is the legacy single-trigger field kept only so workflows persisted
+	// before Triggers existed still decode (and are not silently dropped on
+	// re-save). New code should read and write Triggers; call NormalizeTriggers to
+	// fold any legacy value into Triggers.
+	//
+	// Deprecated: use Triggers.
+	Trigger        *WorkflowTrigger `json:"trigger,omitempty" bson:"trigger,omitempty"`
+	Nodes          []WorkflowNode   `json:"nodes" bson:"nodes"`
+	Edges          []WorkflowEdge   `json:"edges" bson:"edges"`
+	UserId         string           `json:"user_id" bson:"user_id,omitempty"`
+	Username       string           `json:"username" bson:"username,omitempty"`
+	OrganisationId string           `json:"organisation_id" bson:"organisation_id,omitempty"`
+	CreatedAt      int64            `json:"created_at" bson:"created_at,omitempty"`
+	UpdatedAt      int64            `json:"updated_at" bson:"updated_at,omitempty"`
+}
+
+// NormalizeTriggers folds a legacy single Trigger into the Triggers list and
+// clears the deprecated field, so callers only ever have to reason about
+// Triggers. It is idempotent: if Triggers is already populated the legacy field
+// is simply dropped, and if neither is set it does nothing.
+func (w *Workflow) NormalizeTriggers() {
+	if w.Trigger != nil {
+		if len(w.Triggers) == 0 {
+			w.Triggers = append(w.Triggers, *w.Trigger)
+		}
+		w.Trigger = nil
+	}
+}
+
+// ManualTriggersForSurface returns the workflow's manual triggers that are
+// launchable from surface. It normalizes legacy triggers first, so a workflow
+// authored before manual triggers existed (automatic-only) simply yields none.
+func (w *Workflow) ManualTriggersForSurface(surface WorkflowTriggerSurface) []WorkflowTrigger {
+	w.NormalizeTriggers()
+	var out []WorkflowTrigger
+	for _, t := range w.Triggers {
+		if t.EffectiveType() == WorkflowTriggerManual && t.HasSurface(surface) {
+			out = append(out, t)
+		}
+	}
+	return out
 }
 
 // Input / Output types for repository operations

--- a/pkg/models/workflow_test.go
+++ b/pkg/models/workflow_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 
 	"go.mongodb.org/mongo-driver/bson"
 )
@@ -28,12 +29,12 @@ func TestWorkflowTrigger_HasSurface(t *testing.T) {
 }
 
 func TestWorkflow_NormalizeTriggers_FoldsLegacySingle(t *testing.T) {
-	w := Workflow{Trigger: &WorkflowTrigger{Selection: "cam-1"}}
+	w := Workflow{Trigger: &WorkflowTrigger{Devices: []DeviceKey{{Key: "cam-1"}}}}
 	w.NormalizeTriggers()
 	if w.Trigger != nil {
 		t.Fatal("legacy Trigger should be cleared after normalize")
 	}
-	if len(w.Triggers) != 1 || w.Triggers[0].Selection != "cam-1" {
+	if len(w.Triggers) != 1 || len(w.Triggers[0].Devices) != 1 || w.Triggers[0].Devices[0].Key != "cam-1" {
 		t.Fatalf("legacy trigger should fold into Triggers, got %+v", w.Triggers)
 	}
 	// Idempotent.
@@ -46,7 +47,7 @@ func TestWorkflow_NormalizeTriggers_FoldsLegacySingle(t *testing.T) {
 func TestWorkflow_NormalizeTriggers_PrefersListOverLegacy(t *testing.T) {
 	w := Workflow{
 		Triggers: []WorkflowTrigger{{Type: WorkflowTriggerManual, Surfaces: []WorkflowTriggerSurface{WorkflowSurfaceCase}}},
-		Trigger:  &WorkflowTrigger{Selection: "legacy"},
+		Trigger:  &WorkflowTrigger{Devices: []DeviceKey{{Key: "legacy"}}},
 	}
 	w.NormalizeTriggers()
 	if w.Trigger != nil {
@@ -59,7 +60,7 @@ func TestWorkflow_NormalizeTriggers_PrefersListOverLegacy(t *testing.T) {
 
 func TestWorkflow_ManualTriggersForSurface(t *testing.T) {
 	w := Workflow{Triggers: []WorkflowTrigger{
-		{Type: WorkflowTriggerAutomatic, Selection: "all"},
+		{Type: WorkflowTriggerAutomatic, Devices: []DeviceKey{{Key: "cam-1"}}},
 		{Type: WorkflowTriggerManual, Surfaces: []WorkflowTriggerSurface{WorkflowSurfaceMedia}},
 		{Type: WorkflowTriggerManual, Surfaces: []WorkflowTriggerSurface{WorkflowSurfaceCase}},
 	}}
@@ -68,7 +69,7 @@ func TestWorkflow_ManualTriggersForSurface(t *testing.T) {
 		t.Fatalf("expected exactly one manual/case trigger, got %d", len(got))
 	}
 	// A legacy automatic-only workflow yields none.
-	legacy := Workflow{Trigger: &WorkflowTrigger{Selection: "cam-1"}}
+	legacy := Workflow{Trigger: &WorkflowTrigger{Devices: []DeviceKey{{Key: "cam-1"}}}}
 	if got := legacy.ManualTriggersForSurface(WorkflowSurfaceCase); len(got) != 0 {
 		t.Fatalf("legacy automatic-only workflow should have no manual triggers, got %d", len(got))
 	}
@@ -81,7 +82,7 @@ func TestWorkflow_LegacyTriggerBSONRoundTrip(t *testing.T) {
 	legacyDoc := bson.M{
 		"name":    "legacy",
 		"enabled": true,
-		"trigger": bson.M{"selection": "cam-1", "startAt": "08:00"},
+		"trigger": bson.M{"type": "automatic", "devices": bson.A{bson.M{"key": "cam-1"}}},
 	}
 	raw, err := bson.Marshal(legacyDoc)
 	if err != nil {
@@ -91,11 +92,11 @@ func TestWorkflow_LegacyTriggerBSONRoundTrip(t *testing.T) {
 	if err := bson.Unmarshal(raw, &w); err != nil {
 		t.Fatalf("unmarshal legacy doc: %v", err)
 	}
-	if w.Trigger == nil || w.Trigger.Selection != "cam-1" {
+	if w.Trigger == nil || len(w.Trigger.Devices) != 1 || w.Trigger.Devices[0].Key != "cam-1" {
 		t.Fatalf("legacy trigger should decode into deprecated field, got %+v", w.Trigger)
 	}
 	w.NormalizeTriggers()
-	if len(w.Triggers) != 1 || w.Triggers[0].StartAt != "08:00" {
+	if len(w.Triggers) != 1 || len(w.Triggers[0].Devices) != 1 || w.Triggers[0].Devices[0].Key != "cam-1" {
 		t.Fatalf("legacy trigger should fold forward on normalize, got %+v", w.Triggers)
 	}
 }
@@ -112,8 +113,87 @@ func TestWorkflowTrigger_JSONOmitsEmptyMode(t *testing.T) {
 	if want := `"surfaces":["case"]`; !strings.Contains(s, want) {
 		t.Fatalf("expected %s in %s", want, s)
 	}
-	// Automatic-only scheduling fields must not leak when unset.
-	if strings.Contains(s, `"selection"`) {
-		t.Fatalf("unset selection should be omitted, got %s", s)
+	// Automatic-only scoping fields must not leak when unset.
+	if strings.Contains(s, `"devices"`) {
+		t.Fatalf("unset devices should be omitted, got %s", s)
+	}
+	if strings.Contains(s, `"weeklySchedule"`) {
+		t.Fatalf("unset weeklySchedule should be omitted, got %s", s)
+	}
+}
+
+func TestWorkflowTrigger_MatchesDevice(t *testing.T) {
+	// Empty Devices matches every device.
+	if !(WorkflowTrigger{}).MatchesDevice("cam-9") {
+		t.Fatal("empty device list should match any device")
+	}
+	trg := WorkflowTrigger{Devices: []DeviceKey{{Key: "cam-1"}, {Key: "cam-2"}}}
+	if !trg.MatchesDevice("cam-2") {
+		t.Fatal("expected listed device to match")
+	}
+	if trg.MatchesDevice("cam-9") {
+		t.Fatal("did not expect unlisted device to match")
+	}
+}
+
+func TestWorkflowTrigger_IsScheduledAt(t *testing.T) {
+	// Empty schedule matches any time.
+	if !(WorkflowTrigger{}).IsScheduledAt(time.Now()) {
+		t.Fatal("empty schedule should match any time")
+	}
+	loc, err := time.LoadLocation("Europe/Brussels")
+	if err != nil {
+		t.Fatalf("load location: %v", err)
+	}
+	// Wednesday 2024-01-03, 09:00 local. time.Weekday: Wednesday == 3.
+	wed := time.Date(2024, 1, 3, 9, 0, 0, 0, loc)
+	trg := WorkflowTrigger{WeeklySchedule: []*WeeklySchedule{{
+		Day:      int(time.Wednesday),
+		Enabled:  true,
+		Timezone: "Europe/Brussels",
+		Segments: []DayTimeRange{{Start: 8 * 3600, End: 18 * 3600}},
+	}}}
+	if !trg.IsScheduledAt(wed) {
+		t.Fatal("expected in-window Wednesday time to match")
+	}
+	// Same clock time on Thursday should not match the Wednesday schedule.
+	thu := time.Date(2024, 1, 4, 9, 0, 0, 0, loc)
+	if trg.IsScheduledAt(thu) {
+		t.Fatal("did not expect Thursday to match a Wednesday-only schedule")
+	}
+	// Outside the daily window on the right day should not match.
+	wedEarly := time.Date(2024, 1, 3, 7, 0, 0, 0, loc)
+	if trg.IsScheduledAt(wedEarly) {
+		t.Fatal("did not expect pre-window time to match")
+	}
+}
+
+func TestWorkflowTrigger_Matches(t *testing.T) {
+	loc, err := time.LoadLocation("Europe/Brussels")
+	if err != nil {
+		t.Fatalf("load location: %v", err)
+	}
+	wed := time.Date(2024, 1, 3, 9, 0, 0, 0, loc)
+	trg := WorkflowTrigger{
+		Devices: []DeviceKey{{Key: "cam-1"}},
+		WeeklySchedule: []*WeeklySchedule{{
+			Day:      int(time.Wednesday),
+			Enabled:  true,
+			Timezone: "Europe/Brussels",
+			Segments: []DayTimeRange{{Start: 8 * 3600, End: 18 * 3600}},
+		}},
+	}
+	if !trg.Matches("cam-1", wed) {
+		t.Fatal("expected in-scope device and time to match")
+	}
+	if trg.Matches("cam-9", wed) {
+		t.Fatal("wrong device should not match even when time is in window")
+	}
+	if trg.Matches("cam-1", wed.Add(24*time.Hour)) {
+		t.Fatal("right device but out-of-schedule time should not match")
+	}
+	// A bare automatic trigger (no scoping) matches everything.
+	if !(WorkflowTrigger{}).Matches("anything", wed) {
+		t.Fatal("empty automatic trigger should match any device/time")
 	}
 }

--- a/pkg/models/workflow_test.go
+++ b/pkg/models/workflow_test.go
@@ -1,0 +1,119 @@
+package models
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+func TestWorkflowTrigger_EffectiveType(t *testing.T) {
+	if got := (WorkflowTrigger{}).EffectiveType(); got != WorkflowTriggerAutomatic {
+		t.Fatalf("empty Type should default to automatic, got %q", got)
+	}
+	if got := (WorkflowTrigger{Type: WorkflowTriggerManual}).EffectiveType(); got != WorkflowTriggerManual {
+		t.Fatalf("explicit Type should be preserved, got %q", got)
+	}
+}
+
+func TestWorkflowTrigger_HasSurface(t *testing.T) {
+	trg := WorkflowTrigger{Type: WorkflowTriggerManual, Surfaces: []WorkflowTriggerSurface{WorkflowSurfaceCase}}
+	if !trg.HasSurface(WorkflowSurfaceCase) {
+		t.Fatal("expected case surface to match")
+	}
+	if trg.HasSurface(WorkflowSurfaceMedia) {
+		t.Fatal("did not expect media surface to match")
+	}
+}
+
+func TestWorkflow_NormalizeTriggers_FoldsLegacySingle(t *testing.T) {
+	w := Workflow{Trigger: &WorkflowTrigger{Selection: "cam-1"}}
+	w.NormalizeTriggers()
+	if w.Trigger != nil {
+		t.Fatal("legacy Trigger should be cleared after normalize")
+	}
+	if len(w.Triggers) != 1 || w.Triggers[0].Selection != "cam-1" {
+		t.Fatalf("legacy trigger should fold into Triggers, got %+v", w.Triggers)
+	}
+	// Idempotent.
+	w.NormalizeTriggers()
+	if len(w.Triggers) != 1 {
+		t.Fatalf("normalize should be idempotent, got %d triggers", len(w.Triggers))
+	}
+}
+
+func TestWorkflow_NormalizeTriggers_PrefersListOverLegacy(t *testing.T) {
+	w := Workflow{
+		Triggers: []WorkflowTrigger{{Type: WorkflowTriggerManual, Surfaces: []WorkflowTriggerSurface{WorkflowSurfaceCase}}},
+		Trigger:  &WorkflowTrigger{Selection: "legacy"},
+	}
+	w.NormalizeTriggers()
+	if w.Trigger != nil {
+		t.Fatal("legacy Trigger should be dropped when Triggers is populated")
+	}
+	if len(w.Triggers) != 1 || w.Triggers[0].Type != WorkflowTriggerManual {
+		t.Fatalf("existing Triggers should win over legacy, got %+v", w.Triggers)
+	}
+}
+
+func TestWorkflow_ManualTriggersForSurface(t *testing.T) {
+	w := Workflow{Triggers: []WorkflowTrigger{
+		{Type: WorkflowTriggerAutomatic, Selection: "all"},
+		{Type: WorkflowTriggerManual, Surfaces: []WorkflowTriggerSurface{WorkflowSurfaceMedia}},
+		{Type: WorkflowTriggerManual, Surfaces: []WorkflowTriggerSurface{WorkflowSurfaceCase}},
+	}}
+	got := w.ManualTriggersForSurface(WorkflowSurfaceCase)
+	if len(got) != 1 {
+		t.Fatalf("expected exactly one manual/case trigger, got %d", len(got))
+	}
+	// A legacy automatic-only workflow yields none.
+	legacy := Workflow{Trigger: &WorkflowTrigger{Selection: "cam-1"}}
+	if got := legacy.ManualTriggersForSurface(WorkflowSurfaceCase); len(got) != 0 {
+		t.Fatalf("legacy automatic-only workflow should have no manual triggers, got %d", len(got))
+	}
+}
+
+// Legacy workflow_runs / workflows stored a single "trigger" subdocument. Decoding
+// such a document must still populate the deprecated field so NormalizeTriggers
+// can fold it forward rather than silently dropping the data on re-save.
+func TestWorkflow_LegacyTriggerBSONRoundTrip(t *testing.T) {
+	legacyDoc := bson.M{
+		"name":    "legacy",
+		"enabled": true,
+		"trigger": bson.M{"selection": "cam-1", "startAt": "08:00"},
+	}
+	raw, err := bson.Marshal(legacyDoc)
+	if err != nil {
+		t.Fatalf("marshal legacy doc: %v", err)
+	}
+	var w Workflow
+	if err := bson.Unmarshal(raw, &w); err != nil {
+		t.Fatalf("unmarshal legacy doc: %v", err)
+	}
+	if w.Trigger == nil || w.Trigger.Selection != "cam-1" {
+		t.Fatalf("legacy trigger should decode into deprecated field, got %+v", w.Trigger)
+	}
+	w.NormalizeTriggers()
+	if len(w.Triggers) != 1 || w.Triggers[0].StartAt != "08:00" {
+		t.Fatalf("legacy trigger should fold forward on normalize, got %+v", w.Triggers)
+	}
+}
+
+func TestWorkflowTrigger_JSONOmitsEmptyMode(t *testing.T) {
+	b, err := json.Marshal(WorkflowTrigger{Type: WorkflowTriggerManual, Surfaces: []WorkflowTriggerSurface{WorkflowSurfaceCase}})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	s := string(b)
+	if want := `"type":"manual"`; !strings.Contains(s, want) {
+		t.Fatalf("expected %s in %s", want, s)
+	}
+	if want := `"surfaces":["case"]`; !strings.Contains(s, want) {
+		t.Fatalf("expected %s in %s", want, s)
+	}
+	// Automatic-only scheduling fields must not leak when unset.
+	if strings.Contains(s, `"selection"`) {
+		t.Fatalf("unset selection should be omitted, got %s", s)
+	}
+}

--- a/pkg/models/workflowrun.go
+++ b/pkg/models/workflowrun.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"crypto/sha256"
 	"encoding/json"
 
 	"go.mongodb.org/mongo-driver/bson/primitive"
@@ -272,6 +273,30 @@ func (r WorkflowRun) MarshalJSON() ([]byte, error) {
 		w.RunId = r.Id.Hex()
 	}
 	return json.Marshal(w)
+}
+
+// AutomaticRunObjectID derives the DETERMINISTIC run identity for an automatic
+// run of a given workflow over a given recording, from the natural triple
+// (media key, organisation, workflow). It is the single source of truth both the
+// producer (analysis, which mints it) and any consumer that re-derives it must
+// agree on, so the same recording teed into the same workflow always maps to the
+// same run: a redelivered pipeline event upserts the one run document rather than
+// opening a duplicate. Because it returns a primitive.ObjectID it becomes the
+// run's _id, and the wire RunId falls out of it for free via MarshalJSON
+// (RunId == Id.Hex()) — the identity is minted once and projected everywhere.
+//
+// It is intentionally NOT used for manual runs: those mint a fresh ObjectID per
+// launch (primitive.NewObjectID) so re-pressing a button opens a new run, while a
+// redelivered copy of that one launch still dedupes on its already-minted id.
+//
+// The triple is hashed with a NUL separator so the field boundaries are
+// unambiguous (no two distinct triples can concatenate to the same input), and
+// the first 12 bytes of the digest form the ObjectID.
+func AutomaticRunObjectID(mediaKey, organisationId, workflowId string) primitive.ObjectID {
+	sum := sha256.Sum256([]byte(mediaKey + "\x00" + organisationId + "\x00" + workflowId))
+	var id primitive.ObjectID
+	copy(id[:], sum[:])
+	return id
 }
 
 // WorkflowUser is the secret-free projection of the owning account carried on a

--- a/pkg/models/workflowrun.go
+++ b/pkg/models/workflowrun.go
@@ -6,6 +6,21 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
+// WorkflowRunOrigin records how a run was opened: automatically (teed off the
+// pipeline by analysis for a matching recording) or manually (launched on demand
+// by a user from a surface). It is the run-side counterpart of a Workflow
+// trigger's Type, and shares its values.
+type WorkflowRunOrigin string
+
+const (
+	// WorkflowOriginAutomatic is a run opened by the automatic pipeline tee. It is
+	// also the default for runs opened before origins were recorded.
+	WorkflowOriginAutomatic WorkflowRunOrigin = "automatic"
+	// WorkflowOriginManual is a run launched on demand by a user from a surface.
+	// The engine skips automatic selection/time gating for manual runs.
+	WorkflowOriginManual WorkflowRunOrigin = "manual"
+)
+
 // WorkflowRun is the single type the workflow subsystem uses for a run, in both
 // of its representations:
 //
@@ -73,10 +88,18 @@ type WorkflowRun struct {
 	// is empty on the analysis hand-off — the run is keyed by Key until the
 	// engine opens it — and set on every engine→worker dispatch. The persisted
 	// identity is Id, so RunId itself is wire-only.
+	//
+	// It is never set by hand: MarshalJSON derives it from Id whenever a run that
+	// has been opened (its _id is set) is serialized, so a producer only has to
+	// stamp Id and the two representations can never drift. A run without an Id
+	// yet (the analysis hand-off) keeps whatever RunId it was given (normally
+	// empty, so runId is omitted).
 	RunId string `json:"runId,omitempty" bson:"-"`
 
 	// Id is the run document's Mongo identity. Persistence-only — on the wire the
-	// run is referenced by RunId (Id.Hex()).
+	// run is referenced by RunId (Id.Hex()). Setting Id is sufficient for the
+	// wire identity: MarshalJSON emits RunId from it, so callers never derive the
+	// hex themselves.
 	Id primitive.ObjectID `json:"-" bson:"_id,omitempty"`
 
 	// WorkflowId is the id of the Workflow definition (models.Workflow) this run
@@ -90,6 +113,22 @@ type WorkflowRun struct {
 	// dispatch/result is legible in worker context and logs without a lookup.
 	// Populated alongside WorkflowId.
 	WorkflowName string `json:"workflowName,omitempty" bson:"workflowname,omitempty"`
+
+	// Origin records how this run was opened — the run-side counterpart of the
+	// Workflow's trigger Type. An automatic run was teed off the pipeline by
+	// analysis for a matching recording; a manual run was launched on demand by a
+	// user from a surface. The engine reads it to skip automatic selection/time
+	// gating for on-demand runs; it is persisted so "all runs for a media key" can
+	// be filtered by how they started. Empty is treated as automatic for runs
+	// opened before origins existed.
+	Origin WorkflowRunOrigin `json:"origin,omitempty" bson:"origin,omitempty"`
+
+	// SourceRef ties a manual run back to the thing it was launched from — e.g.
+	// the case id when launched from a case surface — so sibling runs fanned out
+	// from one user action (one seed per selected media key) can be grouped above
+	// the run. Empty for automatic runs. It generalises to any run-grouping handle
+	// (a case id today; a temporal device-series id is a forward-looking twin).
+	SourceRef string `json:"sourceRef,omitempty" bson:"sourceref,omitempty"`
 
 	// Key is the media key the run is about: its natural identity, used to load
 	// or open the run document. Copied from the recording at hand-off time.
@@ -212,6 +251,27 @@ type WorkflowRun struct {
 	// that seeds Inputs but never resolves as a stage and so never appears here.
 	// Persistence-only.
 	ResolvedOperations []string `json:"-" bson:"resolvedoperations,omitempty"`
+}
+
+// MarshalJSON is the single place the persisted identity (Id) is projected onto
+// the wire identity (RunId), so the two representations can never drift. A value
+// ObjectID cannot itself represent "no id yet" in JSON (its zero marshals to the
+// all-zero hex, which encoding/json's omitempty does not drop), so the identity
+// is carried on the wire by the companion RunId string instead: whenever a run
+// that has been opened (its _id is set) is serialized, RunId is emitted as
+// Id.Hex(); a run without an Id keeps whatever RunId it was given (normally
+// empty, so runId is omitted). Producers therefore only ever set Id — the hex
+// projection is automatic and impossible to forget.
+//
+// The alias type strips WorkflowRun's own MarshalJSON for the inner encode, so
+// this does not recurse.
+func (r WorkflowRun) MarshalJSON() ([]byte, error) {
+	type wire WorkflowRun
+	w := wire(r)
+	if !r.Id.IsZero() {
+		w.RunId = r.Id.Hex()
+	}
+	return json.Marshal(w)
 }
 
 // WorkflowUser is the secret-free projection of the owning account carried on a

--- a/pkg/models/workflowrun_test.go
+++ b/pkg/models/workflowrun_test.go
@@ -69,3 +69,48 @@ func TestWorkflowRun_MarshalJSON_ProjectsRunIdFromId(t *testing.T) {
 		}
 	})
 }
+
+// TestAutomaticRunObjectID asserts the deterministic automatic run identity:
+// stable for a given (key, org, workflow) triple, distinct across triples, never
+// zero, and — via MarshalJSON — projected onto the wire RunId so producer and
+// engine agree on the same runId.
+func TestAutomaticRunObjectID(t *testing.T) {
+	a := AutomaticRunObjectID("media-1", "org-1", "wf-1")
+
+	t.Run("deterministic for the same triple", func(t *testing.T) {
+		if b := AutomaticRunObjectID("media-1", "org-1", "wf-1"); a != b {
+			t.Errorf("same triple produced different ids: %s vs %s", a.Hex(), b.Hex())
+		}
+	})
+
+	t.Run("not the zero id", func(t *testing.T) {
+		if a.IsZero() {
+			t.Error("derived id should never be zero")
+		}
+	})
+
+	t.Run("distinct per field, with unambiguous boundaries", func(t *testing.T) {
+		cases := map[string]primitive.ObjectID{
+			"other key":      AutomaticRunObjectID("media-2", "org-1", "wf-1"),
+			"other org":      AutomaticRunObjectID("media-1", "org-2", "wf-1"),
+			"other workflow": AutomaticRunObjectID("media-1", "org-1", "wf-2"),
+			// Without a separator these two would hash the same bytes.
+			"boundary shift": AutomaticRunObjectID("media", "1org", "1wf-1"),
+		}
+		for name, id := range cases {
+			if id == a {
+				t.Errorf("%s should differ from the base id", name)
+			}
+		}
+	})
+
+	t.Run("projects onto the wire runId via MarshalJSON", func(t *testing.T) {
+		b, err := json.Marshal(WorkflowRun{Operation: "event", Key: "media-1", Id: a})
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if want := `"runId":"` + a.Hex() + `"`; !strings.Contains(string(b), want) {
+			t.Errorf("expected %s in %s", want, b)
+		}
+	})
+}

--- a/pkg/models/workflowrun_test.go
+++ b/pkg/models/workflowrun_test.go
@@ -1,0 +1,71 @@
+package models
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+// TestWorkflowRun_MarshalJSON_ProjectsRunIdFromId asserts the single-source-of-truth
+// invariant: RunId is the wire projection of the persisted Id, derived automatically
+// at marshal time so a producer only ever sets Id and the two representations can
+// never drift.
+func TestWorkflowRun_MarshalJSON_ProjectsRunIdFromId(t *testing.T) {
+	id := primitive.NewObjectID()
+
+	t.Run("set Id emits runId as the hex", func(t *testing.T) {
+		b, err := json.Marshal(WorkflowRun{Operation: "anpr", Key: "media-1", Id: id})
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		var wire map[string]any
+		if err := json.Unmarshal(b, &wire); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if got := wire["runId"]; got != id.Hex() {
+			t.Errorf("runId = %v, want %s", got, id.Hex())
+		}
+		// The persisted identity itself never appears on the wire.
+		if _, ok := wire["_id"]; ok {
+			t.Errorf("wire carried _id; Id must stay persistence-only")
+		}
+		if _, ok := wire["id"]; ok {
+			t.Errorf("wire carried id; Id must stay persistence-only")
+		}
+	})
+
+	t.Run("zero Id omits runId", func(t *testing.T) {
+		b, err := json.Marshal(WorkflowRun{Operation: "event", Key: "media-1"})
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if strings.Contains(string(b), "runId") {
+			t.Errorf("runId present on a run with no Id yet: %s", b)
+		}
+	})
+
+	t.Run("pointer marshal path also projects", func(t *testing.T) {
+		b, err := json.Marshal(&WorkflowRun{Id: id})
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if !strings.Contains(string(b), id.Hex()) {
+			t.Errorf("pointer marshal did not project runId: %s", b)
+		}
+	})
+
+	t.Run("wire round-trip keeps RunId and leaves Id zero", func(t *testing.T) {
+		var r WorkflowRun
+		if err := json.Unmarshal([]byte(`{"operation":"anpr","runId":"`+id.Hex()+`"}`), &r); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if r.RunId != id.Hex() {
+			t.Errorf("RunId = %q, want %s", r.RunId, id.Hex())
+		}
+		if !r.Id.IsZero() {
+			t.Errorf("Id = %s, want zero (Id is json:\"-\", never read off the wire)", r.Id.Hex())
+		}
+	})
+}


### PR DESCRIPTION
## Description

## Summary

This PR expands workflow triggering to support both automatic and manual execution modes, while introducing stable run identity semantics for workflow runs.

## Motivation

Workflows were previously limited to a single implicit trigger model tied to device/time filtering. That made workflows difficult to reuse across different product surfaces and prevented user-driven execution flows.

This change introduces:
- Explicit trigger types (`automatic` and `manual`)
- Surface-aware manual workflow launching
- Multiple triggers per workflow
- Deterministic run identity for automatic runs
- Explicit workflow run origin tracking

These additions make workflows significantly more flexible while preserving backward compatibility with existing persisted data.

## Why this improves the project

### Enables user-driven workflows
Manual triggers allow workflows to be launched directly from UI surfaces such as cases or media items. This unlocks interactive workflow execution without hardcoded workflow-to-surface mappings.

### Separates activation concerns cleanly
Automatic workflows continue to use device and schedule matching, while manual workflows are scoped by launch surface instead of time/device constraints. This creates a clearer and more maintainable execution model.

### Supports hybrid workflows
A workflow can now expose both automatic and manual triggers simultaneously, enabling reuse of the same workflow definition across automated pipelines and on-demand user actions.

### Preserves backward compatibility
Legacy single-trigger workflows continue to function unchanged:
- Empty trigger types default to `automatic`
- Existing persisted `trigger` fields are normalized into the new `triggers` list
- BSON compatibility tests ensure older documents remain readable and safe to re-save

### Improves workflow run traceability
Workflow runs now explicitly record:
- Whether they were started automatically or manually
- The originating surface/context (`SourceRef`)

This improves observability, filtering, and grouping of related runs.

### Prevents duplicate automatic runs
Automatic runs now derive deterministic ObjectIDs from `(media key, organisation, workflow)`.

This guarantees:
- Redelivered events resolve to the same workflow run
- Duplicate automatic runs are avoided
- Producer and consumer systems share a single source of truth for run identity

### Centralizes wire identity handling
`WorkflowRun.MarshalJSON` now derives `runId` directly from the persisted Mongo `_id`.

This eliminates duplicated identity generation logic and prevents drift between persistence and wire representations.

## Additional notes

The PR also adds extensive unit coverage around:
- Trigger normalization
- Manual trigger surface filtering
- Device/schedule matching
- JSON/BSON compatibility
- Deterministic run identity generation
- `runId` projection semantics