### PR TITLE
feat(workflow): Source provenance, Stages projection & AutomaticMatches

### DIFF
--- a/pkg/models/workflow.go
+++ b/pkg/models/workflow.go
@@ -188,6 +188,25 @@ func (t WorkflowTrigger) Matches(deviceKey string, at time.Time) bool {
 	return t.MatchesDevice(deviceKey) && t.IsScheduledAt(at)
 }
 
+// WorkflowSource is the provenance of a workflow document, which also decides
+// its availability. It is a named string (not a boolean) so further provenances
+// can be added without a schema change. An empty Source is treated as
+// WorkflowSourceUser.
+type WorkflowSource string
+
+const (
+	// WorkflowSourceUser is a workflow authored by a user through the API and
+	// scoped to that user's organisation. It is the default (an empty Source is
+	// treated as this) and is editable in the UI.
+	WorkflowSourceUser WorkflowSource = "user"
+	// WorkflowSourceConfig is a workflow seeded from deployment configuration
+	// (helm). It is deployment-global — available to every organisation — and
+	// ops-managed: created and updated only by the seeding reconcile, and
+	// read-only in the UI. A config workflow carries an empty OrganisationId to
+	// signal its global scope (see IsGlobal).
+	WorkflowSourceConfig WorkflowSource = "config"
+)
+
 // Workflow is a user-defined automation graph composed of stage-instance nodes
 // and the edges that route between them. Triggers say what activates it (a
 // workflow may have several — e.g. an automatic trigger and a manual one); the
@@ -197,6 +216,12 @@ type Workflow struct {
 	Name        string             `json:"name" bson:"name,omitempty"`
 	Description string             `json:"description" bson:"description,omitempty"`
 	Enabled     bool               `json:"enabled" bson:"enabled"`
+	// Source is the workflow's provenance and availability (see WorkflowSource).
+	// Empty means WorkflowSourceUser: an ordinary user workflow scoped to its
+	// OrganisationId. WorkflowSourceConfig marks a helm-seeded, deployment-global,
+	// read-only workflow. Every workflow persisted before this field existed
+	// decodes as user.
+	Source WorkflowSource `json:"source,omitempty" bson:"source,omitempty"`
 	// Triggers is the set of activation modes for this workflow. A workflow may
 	// carry both an automatic and a manual trigger so it runs on its own for
 	// matching recordings and can also be launched on demand from a surface.
@@ -207,14 +232,91 @@ type Workflow struct {
 	// fold any legacy value into Triggers.
 	//
 	// Deprecated: use Triggers.
-	Trigger        *WorkflowTrigger `json:"trigger,omitempty" bson:"trigger,omitempty"`
-	Nodes          []WorkflowNode   `json:"nodes" bson:"nodes"`
-	Edges          []WorkflowEdge   `json:"edges" bson:"edges"`
-	UserId         string           `json:"user_id" bson:"user_id,omitempty"`
-	Username       string           `json:"username" bson:"username,omitempty"`
-	OrganisationId string           `json:"organisation_id" bson:"organisation_id,omitempty"`
-	CreatedAt      int64            `json:"created_at" bson:"created_at,omitempty"`
-	UpdatedAt      int64            `json:"updated_at" bson:"updated_at,omitempty"`
+	Trigger *WorkflowTrigger `json:"trigger,omitempty" bson:"trigger,omitempty"`
+	Nodes   []WorkflowNode   `json:"nodes" bson:"nodes"`
+	Edges   []WorkflowEdge   `json:"edges" bson:"edges"`
+	// Stages is the workflow's executable stage set: the runtime-authoritative
+	// projection the engine dispatches against. When set it is used as-is (config
+	// workflows author it directly in the helm registry form: operation, dispatch,
+	// needs, needsMode); when empty it is derived from Nodes+Edges on demand (UI
+	// workflows author the graph and CompileStages projects it). Read it through
+	// CompileStages, never directly, so both authoring styles resolve uniformly.
+	//
+	// Only the routing fields (Operation, Dispatch, Needs, NeedsMode) are
+	// meaningful here; a stage's deployment fields (image, queue, replicas, …) are
+	// resolved by Operation against the shared deployed catalog, not per workflow.
+	// Operations need only be unique within a single workflow, not globally.
+	Stages         []WorkflowStage `json:"stages,omitempty" bson:"stages,omitempty"`
+	UserId         string          `json:"user_id" bson:"user_id,omitempty"`
+	Username       string          `json:"username" bson:"username,omitempty"`
+	OrganisationId string          `json:"organisation_id" bson:"organisation_id,omitempty"`
+	CreatedAt      int64           `json:"created_at" bson:"created_at,omitempty"`
+	UpdatedAt      int64           `json:"updated_at" bson:"updated_at,omitempty"`
+}
+
+// EffectiveSource returns the workflow's provenance, defaulting an empty Source
+// to WorkflowSourceUser so workflows persisted before Source existed keep their
+// original (user) behaviour.
+func (w *Workflow) EffectiveSource() WorkflowSource {
+	if w.Source == "" {
+		return WorkflowSourceUser
+	}
+	return w.Source
+}
+
+// IsGlobal reports whether this workflow is available to every organisation. A
+// global workflow is one seeded from deployment configuration
+// (WorkflowSourceConfig) with no owning organisation, so surfaces list it
+// alongside the caller's own workflows without any per-org copy.
+func (w *Workflow) IsGlobal() bool {
+	return w.EffectiveSource() == WorkflowSourceConfig && w.OrganisationId == ""
+}
+
+// CompileStages returns the workflow's executable stage set — the routing the
+// engine dispatches against. It is the single entry point for both authoring
+// styles: if Stages is populated (config workflows, authored directly in the
+// helm registry form) it is returned as-is; otherwise it is derived from the
+// graph, projecting each node into a stage and each incoming edge into a need.
+//
+// The projection follows the graph's routing contract (see WorkflowEdge and
+// WorkflowStage.Needs): a node with no incoming edges dispatches always (a start
+// stage); a node with one or more incoming edges dispatches conditionally, with
+// one need per incoming edge — the need's Operation is the edge's source stage
+// (its readiness gate) and the need's Condition is the edge's predicate (nil for
+// an unconditional dependency). NeedsMode is left at its default (any). Only
+// routing fields are populated; deployment is resolved elsewhere by Operation.
+func (w *Workflow) CompileStages() []WorkflowStage {
+	if len(w.Stages) > 0 {
+		return w.Stages
+	}
+	opByNode := make(map[string]string, len(w.Nodes))
+	for _, n := range w.Nodes {
+		opByNode[n.Id] = n.StageRef
+	}
+	incoming := make(map[string][]WorkflowEdge, len(w.Nodes))
+	for _, e := range w.Edges {
+		incoming[e.Target] = append(incoming[e.Target], e)
+	}
+	stages := make([]WorkflowStage, 0, len(w.Nodes))
+	for _, n := range w.Nodes {
+		stage := WorkflowStage{Operation: n.StageRef}
+		edges := incoming[n.Id]
+		if len(edges) == 0 {
+			stage.Dispatch = DispatchAlways
+		} else {
+			stage.Dispatch = DispatchConditional
+			needs := make([]StageDependency, 0, len(edges))
+			for _, e := range edges {
+				needs = append(needs, StageDependency{
+					Operation: opByNode[e.Source],
+					Condition: e.Condition,
+				})
+			}
+			stage.Needs = needs
+		}
+		stages = append(stages, stage)
+	}
+	return stages
 }
 
 // NormalizeTriggers folds a legacy single Trigger into the Triggers list and
@@ -242,6 +344,25 @@ func (w *Workflow) ManualTriggersForSurface(surface WorkflowTriggerSurface) []Wo
 		}
 	}
 	return out
+}
+
+// AutomaticMatches reports whether a recording from deviceKey at instant at
+// activates this workflow automatically. It normalizes legacy triggers, then is
+// true when the workflow is Enabled and any of its automatic triggers matches
+// the recording's device and time (see WorkflowTrigger.Matches). It is the
+// single gate the engine uses to fan an event out to the workflows it should
+// open a run for; manual triggers never activate this way.
+func (w *Workflow) AutomaticMatches(deviceKey string, at time.Time) bool {
+	if !w.Enabled {
+		return false
+	}
+	w.NormalizeTriggers()
+	for _, t := range w.Triggers {
+		if t.EffectiveType() == WorkflowTriggerAutomatic && t.Matches(deviceKey, at) {
+			return true
+		}
+	}
+	return false
 }
 
 // Input / Output types for repository operations

--- a/pkg/models/workflow_test.go
+++ b/pkg/models/workflow_test.go
@@ -197,3 +197,133 @@ func TestWorkflowTrigger_Matches(t *testing.T) {
 		t.Fatal("empty automatic trigger should match any device/time")
 	}
 }
+
+func TestWorkflow_EffectiveSourceAndIsGlobal(t *testing.T) {
+	// Empty Source defaults to user and is never global.
+	w := Workflow{}
+	if got := w.EffectiveSource(); got != WorkflowSourceUser {
+		t.Fatalf("empty Source should default to user, got %q", got)
+	}
+	if w.IsGlobal() {
+		t.Fatal("a user workflow must not be global")
+	}
+	// A config workflow with no org is global.
+	cfg := Workflow{Source: WorkflowSourceConfig}
+	if !cfg.IsGlobal() {
+		t.Fatal("a config workflow with empty org should be global")
+	}
+	// A config workflow pinned to an org is not global.
+	scoped := Workflow{Source: WorkflowSourceConfig, OrganisationId: "org-1"}
+	if scoped.IsGlobal() {
+		t.Fatal("a config workflow scoped to an org must not be global")
+	}
+}
+
+func TestWorkflow_SourceJSONOmitsWhenEmpty(t *testing.T) {
+	b, err := json.Marshal(Workflow{Name: "w"})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(b), `"source"`) {
+		t.Fatalf("empty Source should be omitted, got %s", b)
+	}
+	b, err = json.Marshal(Workflow{Name: "w", Source: WorkflowSourceConfig})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(b), `"source":"config"`) {
+		t.Fatalf("expected source in %s", b)
+	}
+}
+
+func TestWorkflow_CompileStages_FromGraph(t *testing.T) {
+	// classify --(unconditional)--> anpr --(conditional)--> notify
+	w := Workflow{
+		Nodes: []WorkflowNode{
+			{Id: "n1", StageRef: "classify"},
+			{Id: "n2", StageRef: "anpr"},
+			{Id: "n3", StageRef: "notify"},
+		},
+		Edges: []WorkflowEdge{
+			{Id: "e1", Source: "n1", Target: "n2"},
+			{Id: "e2", Source: "n2", Target: "n3", Condition: &StageCondition{Path: "results.anpr.tracks", Op: ConditionOpExists}},
+		},
+	}
+	stages := w.CompileStages()
+	if len(stages) != 3 {
+		t.Fatalf("expected 3 stages, got %d", len(stages))
+	}
+	byOp := map[string]WorkflowStage{}
+	for _, s := range stages {
+		byOp[s.Operation] = s
+	}
+	// Root node has no incoming edges -> always.
+	if byOp["classify"].Dispatch != DispatchAlways {
+		t.Fatalf("classify should dispatch always, got %q", byOp["classify"].Dispatch)
+	}
+	// anpr has an unconditional incoming edge -> conditional with a gated, nil-condition need.
+	anpr := byOp["anpr"]
+	if anpr.Dispatch != DispatchConditional || len(anpr.Needs) != 1 {
+		t.Fatalf("anpr should be conditional with one need, got %+v", anpr)
+	}
+	if anpr.Needs[0].Operation != "classify" || anpr.Needs[0].Condition != nil {
+		t.Fatalf("anpr need should gate on classify with no condition, got %+v", anpr.Needs[0])
+	}
+	// notify has a conditional incoming edge -> its condition is projected onto the need.
+	notify := byOp["notify"]
+	if notify.Dispatch != DispatchConditional || len(notify.Needs) != 1 {
+		t.Fatalf("notify should be conditional with one need, got %+v", notify)
+	}
+	if notify.Needs[0].Operation != "anpr" || notify.Needs[0].Condition == nil || notify.Needs[0].Condition.Path != "results.anpr.tracks" {
+		t.Fatalf("notify need should gate on anpr with the edge condition, got %+v", notify.Needs[0])
+	}
+}
+
+func TestWorkflow_CompileStages_PrefersStoredStages(t *testing.T) {
+	stored := []WorkflowStage{{Operation: "loitering", Dispatch: DispatchAlways}}
+	w := Workflow{
+		Stages: stored,
+		// A graph that would compile differently must be ignored when Stages is set.
+		Nodes: []WorkflowNode{{Id: "n1", StageRef: "somethingelse"}},
+	}
+	stages := w.CompileStages()
+	if len(stages) != 1 || stages[0].Operation != "loitering" {
+		t.Fatalf("stored Stages should be returned as-is, got %+v", stages)
+	}
+}
+
+func TestWorkflow_AutomaticMatches(t *testing.T) {
+	loc, err := time.LoadLocation("Europe/Brussels")
+	if err != nil {
+		t.Fatalf("load location: %v", err)
+	}
+	wed := time.Date(2024, 1, 3, 9, 0, 0, 0, loc)
+	w := Workflow{
+		Enabled: true,
+		Triggers: []WorkflowTrigger{
+			// A manual trigger must never activate automatically.
+			{Type: WorkflowTriggerManual, Surfaces: []WorkflowTriggerSurface{WorkflowSurfaceCase}},
+			// An automatic trigger scoped to cam-1.
+			{Type: WorkflowTriggerAutomatic, Devices: []DeviceKey{{Key: "cam-1"}}},
+		},
+	}
+	if !w.AutomaticMatches("cam-1", wed) {
+		t.Fatal("expected in-scope device to activate the automatic trigger")
+	}
+	if w.AutomaticMatches("cam-9", wed) {
+		t.Fatal("out-of-scope device must not activate")
+	}
+	// A disabled workflow never activates, even with a matching trigger.
+	disabled := w
+	disabled.Enabled = false
+	if disabled.AutomaticMatches("cam-1", wed) {
+		t.Fatal("a disabled workflow must not activate")
+	}
+	// A manual-only workflow never activates automatically.
+	manualOnly := Workflow{Enabled: true, Triggers: []WorkflowTrigger{
+		{Type: WorkflowTriggerManual, Surfaces: []WorkflowTriggerSurface{WorkflowSurfaceCase}},
+	}}
+	if manualOnly.AutomaticMatches("cam-1", wed) {
+		t.Fatal("a manual-only workflow must not activate automatically")
+	}
+}


### PR DESCRIPTION
## Description

This PR introduces workflow provenance, runtime stage projection, and a unified automatic trigger matching API to support deployment-managed workflows and simplify execution logic.

Key improvements:
- Adds `WorkflowSource` to distinguish user-authored workflows from deployment-seeded configuration workflows.
- Enables globally available, read-only workflows managed through Helm/config without requiring per-organisation copies.
- Preserves backward compatibility by treating existing workflows without a `Source` as user workflows.
- Introduces `CompileStages()` as the single runtime entry point for executable workflow stages:
  - Config workflows can define stages directly in runtime form.
  - UI-authored graph workflows are automatically projected into executable stages.
  - Both authoring models now resolve through a consistent execution contract.
- Adds `AutomaticMatches()` to centralize automatic workflow activation logic:
  - Ensures only enabled workflows with automatic triggers activate.
  - Excludes manual-only workflows from automatic execution paths.
  - Consolidates trigger evaluation into a single engine-facing API.

This improves the project by:
- Separating workflow ownership and availability concerns cleanly.
- Making deployment-managed workflows first-class and scalable across organisations.
- Reducing duplication between graph authoring and runtime execution models.
- Simplifying engine logic through explicit, centralized workflow matching and stage compilation behavior.
- Providing strong test coverage for provenance handling, JSON compatibility, stage projection, and trigger activation semantics.