### PR TITLE
feat(workflow): add WorkflowFilter + Workflow.EffectiveID

### DIFF
--- a/pkg/api/workflow.go
+++ b/pkg/api/workflow.go
@@ -63,8 +63,25 @@ func (cs WorkflowStatus) Translate(lang string) string {
 	return cs.String()
 }
 
+// WorkflowFilter narrows a workflow listing. Every field is optional; an unset
+// field does not constrain the result. Scalars are pointers so "not provided" is
+// distinct from a zero value, and DeviceKeys is a set matched against automatic
+// triggers' device scope. It is the workflow counterpart to MediaFilter, posted
+// to /workflows/filter for criteria (notably a set of device keys) that GET
+// query params fit poorly.
+type WorkflowFilter struct {
+	Source      *models.WorkflowSource         `json:"source,omitempty" bson:"source,omitempty"`
+	Surface     *models.WorkflowTriggerSurface `json:"surface,omitempty" bson:"surface,omitempty"`
+	TriggerType *models.WorkflowTriggerType    `json:"triggerType,omitempty" bson:"triggerType,omitempty"`
+	Enabled     *bool                          `json:"enabled,omitempty" bson:"enabled,omitempty"`
+	DeviceKeys  []string                       `json:"deviceKeys,omitempty" bson:"deviceKeys,omitempty"`
+}
+
 // GetWorkflows
-type GetWorkflowsRequest struct{}
+// @Router /workflows/filter [post]
+type GetWorkflowsRequest struct {
+	Filter WorkflowFilter `json:"filter" bson:"filter"`
+}
 type GetWorkflowsResponse struct {
 	Workflows []models.Workflow `json:"workflows"`
 }

--- a/pkg/models/workflow.go
+++ b/pkg/models/workflow.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"crypto/sha256"
 	"time"
 
 	"go.mongodb.org/mongo-driver/bson/primitive"
@@ -270,6 +271,26 @@ func (w *Workflow) EffectiveSource() WorkflowSource {
 // alongside the caller's own workflows without any per-org copy.
 func (w *Workflow) IsGlobal() bool {
 	return w.EffectiveSource() == WorkflowSourceConfig && w.OrganisationId == ""
+}
+
+// EffectiveID resolves the stable, run-facing id of a workflow and is the single
+// source of truth for that derivation. A workflow with an explicit Id (a
+// persisted user workflow, or a config workflow that carries one) uses it; a
+// config workflow seeded from helm without an id gets a deterministic id derived
+// from its Name, so the same definition always yields the same id across
+// restarts and every service agrees on its identity without persisting it — a
+// run one service seeds resolves to the workflow another service loaded from the
+// same definition. The first 12 bytes of a SHA-256 digest form a valid 24-char
+// ObjectID hex; callers that need that hex string (a run's WorkflowId) use
+// EffectiveID().Hex().
+func (w *Workflow) EffectiveID() primitive.ObjectID {
+	if !w.Id.IsZero() {
+		return w.Id
+	}
+	sum := sha256.Sum256([]byte(w.Name))
+	var id primitive.ObjectID
+	copy(id[:], sum[:12])
+	return id
 }
 
 // CompileStages returns the workflow's executable stage set — the routing the

--- a/pkg/models/workflow_test.go
+++ b/pkg/models/workflow_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
 func TestWorkflowTrigger_EffectiveType(t *testing.T) {
@@ -327,3 +328,33 @@ func TestWorkflow_AutomaticMatches(t *testing.T) {
 		t.Fatal("a manual-only workflow must not activate automatically")
 	}
 }
+
+// TestWorkflow_EffectiveID_GoldenVectors pins the deterministic id derivation so
+// it cannot drift. Every service that reads WORKFLOW_DEFINITIONS (hub-api, the
+// workflows engine) relies on this exact scheme to agree on a config workflow's
+// identity without persisting it; if these fixed name→id vectors ever change,
+// runs one service seeds would stop resolving to the workflow another loaded.
+func TestWorkflow_EffectiveID_GoldenVectors(t *testing.T) {
+	vectors := map[string]string{
+		"tracking-workflow":        "ec7e72bc4cedd32018e1f92a",
+		"objecttracking-on-demand": "1d07bbe3a979822d7a60b857",
+	}
+	for name, want := range vectors {
+		got := (&Workflow{Name: name}).EffectiveID().Hex()
+		if got != want {
+			t.Fatalf("EffectiveID(%q) = %q, want %q (id scheme changed?)", name, got, want)
+		}
+	}
+}
+
+// TestWorkflow_EffectiveID_PrefersExplicitID confirms a workflow that already
+// carries an id keeps it rather than deriving one from its name — so persisted
+// user workflows resolve by their stored id.
+func TestWorkflow_EffectiveID_PrefersExplicitID(t *testing.T) {
+	id := primitive.NewObjectID()
+	w := Workflow{Id: id, Name: "tracking-workflow"}
+	if got := w.EffectiveID(); got != id {
+		t.Fatalf("EffectiveID should return the explicit id %s, got %s", id.Hex(), got.Hex())
+	}
+}
+


### PR DESCRIPTION
## Description

Adds a dedicated workflow filtering model and introduces a stable `Workflow.EffectiveID()` for config-defined workflows.

Motivation:
- Workflow listing needed a more expressive filtering mechanism than query params can reasonably support, especially for multi-device matching and optional criteria.
- Config-seeded workflows currently lack a guaranteed stable identity across services and restarts when no explicit ID is provided, which can cause inconsistencies when resolving workflow runs.

What changed:
- Added `WorkflowFilter` and updated `GetWorkflowsRequest` to support POST-based filtering via `/workflows/filter`.
- Added `Workflow.EffectiveID()` as the single source of truth for workflow identity resolution:
  - Explicit persisted IDs are preserved.
  - Config workflows without IDs now derive a deterministic ObjectID from their name using SHA-256.
- Added golden-vector tests to lock the ID derivation scheme and ensure cross-service compatibility over time.

Why this improves the project:
- Makes workflow querying more scalable and maintainable as filtering requirements grow.
- Ensures all services resolve config workflows to the same ID without relying on persistence or runtime coordination.
- Prevents workflow/run mismatches caused by unstable generated IDs.
- Centralizes workflow identity logic, reducing duplication and the risk of drift between services.