### PR TITLE
feat: workflow-run status API + attachment-origin case media sources

### DIFF
--- a/pkg/api/task.go
+++ b/pkg/api/task.go
@@ -504,11 +504,18 @@ type CreateMediaEditRequest struct {
 	// existing row with the same video_file when present), and then
 	// applies the edit to that row. Lets pre-migration cases be
 	// redacted without requiring a workspace-wide backfill.
-	SourceVideoFile string                   `json:"sourceVideoFile,omitempty"`
-	Action          models.CaseMediaAction   `json:"action"`
-	EditType        models.CaseMediaEditType `json:"editType,omitempty"`
-	Params          map[string]interface{}   `json:"params,omitempty"`
-	SupersedesId    string                   `json:"supersedesId,omitempty"`
+	SourceVideoFile string `json:"sourceVideoFile,omitempty"`
+	// SourceAttachmentId points at a video CaseAttachment by its id.
+	// When both SourceCaseMediaId and SourceVideoFile are empty the API
+	// materialises (idempotently — reuses the attachment's linked row
+	// when present) a Role=source CaseMedia from the attachment's stored
+	// video and applies the edit to that row, so an attached video can
+	// be redacted with the same flow as a device recording.
+	SourceAttachmentId string                   `json:"sourceAttachmentId,omitempty"`
+	Action             models.CaseMediaAction   `json:"action"`
+	EditType           models.CaseMediaEditType `json:"editType,omitempty"`
+	Params             map[string]interface{}   `json:"params,omitempty"`
+	SupersedesId       string                   `json:"supersedesId,omitempty"`
 }
 
 type CreateMediaEditResponse struct {

--- a/pkg/api/workflow.go
+++ b/pkg/api/workflow.go
@@ -6,23 +6,25 @@ import "github.com/uug-ai/models/pkg/models"
 type WorkflowStatus string
 
 const (
-	WorkflowBindingFailed    WorkflowStatus = "workflow_binding_failed"
-	WorkflowMissingInfo      WorkflowStatus = "workflow_missing_info"
-	WorkflowFound            WorkflowStatus = "workflow_found"
-	WorkflowNotFound         WorkflowStatus = "workflow_not_found"
-	WorkflowRetrievalSuccess WorkflowStatus = "workflow_retrieval_success"
-	WorkflowRetrievalFailed  WorkflowStatus = "workflow_retrieval_failed"
-	WorkflowAddSuccess       WorkflowStatus = "workflow_add_success"
-	WorkflowAddFailed        WorkflowStatus = "workflow_add_failed"
-	WorkflowUpdateSuccess    WorkflowStatus = "workflow_update_success"
-	WorkflowUpdateFailed     WorkflowStatus = "workflow_update_failed"
-	WorkflowDeleteSuccess    WorkflowStatus = "workflow_delete_success"
-	WorkflowDeleteFailed     WorkflowStatus = "workflow_delete_failed"
-	WorkflowDuplicateName    WorkflowStatus = "workflow_duplicate_name"
-	WorkflowForbidden        WorkflowStatus = "workflow_forbidden"
-	WorkflowRunSuccess       WorkflowStatus = "workflow_run_success"
-	WorkflowRunFailed        WorkflowStatus = "workflow_run_failed"
-	WorkflowRunNoMedia       WorkflowStatus = "workflow_run_no_media"
+	WorkflowBindingFailed       WorkflowStatus = "workflow_binding_failed"
+	WorkflowMissingInfo         WorkflowStatus = "workflow_missing_info"
+	WorkflowFound               WorkflowStatus = "workflow_found"
+	WorkflowNotFound            WorkflowStatus = "workflow_not_found"
+	WorkflowRetrievalSuccess    WorkflowStatus = "workflow_retrieval_success"
+	WorkflowRetrievalFailed     WorkflowStatus = "workflow_retrieval_failed"
+	WorkflowAddSuccess          WorkflowStatus = "workflow_add_success"
+	WorkflowAddFailed           WorkflowStatus = "workflow_add_failed"
+	WorkflowUpdateSuccess       WorkflowStatus = "workflow_update_success"
+	WorkflowUpdateFailed        WorkflowStatus = "workflow_update_failed"
+	WorkflowDeleteSuccess       WorkflowStatus = "workflow_delete_success"
+	WorkflowDeleteFailed        WorkflowStatus = "workflow_delete_failed"
+	WorkflowDuplicateName       WorkflowStatus = "workflow_duplicate_name"
+	WorkflowForbidden           WorkflowStatus = "workflow_forbidden"
+	WorkflowRunSuccess          WorkflowStatus = "workflow_run_success"
+	WorkflowRunFailed           WorkflowStatus = "workflow_run_failed"
+	WorkflowRunNoMedia          WorkflowStatus = "workflow_run_no_media"
+	WorkflowRunsFound           WorkflowStatus = "workflow_runs_found"
+	WorkflowRunsRetrievalFailed WorkflowStatus = "workflow_runs_retrieval_failed"
 )
 
 // String returns the string representation of the workflow status.
@@ -34,23 +36,25 @@ func (cs WorkflowStatus) String() string {
 func (cs WorkflowStatus) Translate(lang string) string {
 	translations := map[string]map[WorkflowStatus]string{
 		"en": {
-			WorkflowBindingFailed:    "Workflow binding failed",
-			WorkflowMissingInfo:      "Workflow missing information",
-			WorkflowFound:            "Workflow found",
-			WorkflowNotFound:         "Workflow not found",
-			WorkflowRetrievalSuccess: "Workflow retrieved successfully",
-			WorkflowRetrievalFailed:  "Workflow retrieval failed",
-			WorkflowAddSuccess:       "Workflow added successfully",
-			WorkflowAddFailed:        "Workflow failed to add",
-			WorkflowUpdateSuccess:    "Workflow updated successfully",
-			WorkflowUpdateFailed:     "Workflow failed to update",
-			WorkflowDeleteSuccess:    "Workflow deleted successfully",
-			WorkflowDeleteFailed:     "Workflow failed to delete",
-			WorkflowDuplicateName:    "Workflow with this name already exists",
-			WorkflowForbidden:        "You do not have permission for this action",
-			WorkflowRunSuccess:       "Workflow run(s) launched successfully",
-			WorkflowRunFailed:        "Workflow run(s) failed to launch",
-			WorkflowRunNoMedia:       "No eligible media to run the workflow on",
+			WorkflowBindingFailed:       "Workflow binding failed",
+			WorkflowMissingInfo:         "Workflow missing information",
+			WorkflowFound:               "Workflow found",
+			WorkflowNotFound:            "Workflow not found",
+			WorkflowRetrievalSuccess:    "Workflow retrieved successfully",
+			WorkflowRetrievalFailed:     "Workflow retrieval failed",
+			WorkflowAddSuccess:          "Workflow added successfully",
+			WorkflowAddFailed:           "Workflow failed to add",
+			WorkflowUpdateSuccess:       "Workflow updated successfully",
+			WorkflowUpdateFailed:        "Workflow failed to update",
+			WorkflowDeleteSuccess:       "Workflow deleted successfully",
+			WorkflowDeleteFailed:        "Workflow failed to delete",
+			WorkflowDuplicateName:       "Workflow with this name already exists",
+			WorkflowForbidden:           "You do not have permission for this action",
+			WorkflowRunSuccess:          "Workflow run(s) launched successfully",
+			WorkflowRunFailed:           "Workflow run(s) failed to launch",
+			WorkflowRunNoMedia:          "No eligible media to run the workflow on",
+			WorkflowRunsFound:           "Workflow runs retrieved successfully",
+			WorkflowRunsRetrievalFailed: "Workflow runs retrieval failed",
 		},
 	}
 
@@ -163,10 +167,14 @@ type DeleteWorkflowErrorResponse struct {
 // WorkflowId is the id of the workflow to run (a config or user workflow that
 // exposes a manual trigger on the case surface). MediaIds is the set of
 // case_media source-row ids to run it over; an empty MediaIds means "every
-// source media on the case".
+// source media on the case". AttachmentIds additionally selects video
+// CaseAttachments to run it over — each is materialised into a linked
+// Role=source case_media row on demand so attached videos flow through the
+// same run machinery as device recordings.
 type RunWorkflowRequest struct {
-	WorkflowId string   `json:"workflowId" bson:"workflowId"`
-	MediaIds   []string `json:"mediaIds,omitempty" bson:"mediaIds,omitempty"`
+	WorkflowId    string   `json:"workflowId" bson:"workflowId"`
+	MediaIds      []string `json:"mediaIds,omitempty" bson:"mediaIds,omitempty"`
+	AttachmentIds []string `json:"attachmentIds,omitempty" bson:"attachmentIds,omitempty"`
 }
 
 // RunWorkflowResponse reports the runs opened by the launch: the freshly minted
@@ -180,5 +188,60 @@ type RunWorkflowSuccessResponse struct {
 	Data RunWorkflowResponse `json:"data"`
 }
 type RunWorkflowErrorResponse struct {
+	ErrorResponse
+}
+
+// WorkflowRunStatus is the slim, client-facing status of a single workflow run,
+// projected from a persisted models.WorkflowRun. It exists because the run's
+// lifecycle fields (start/end, dispatched/resolved) are persistence-only and
+// never cross the wire on the run itself, so the state a surface needs to render
+// "still working" vs "results are in" is derived server-side (via
+// WorkflowRun.LifecycleState) and carried here instead. It is surface-agnostic:
+// the same shape serves a case today and any future launch surface.
+type WorkflowRunStatus struct {
+	RunId        string `json:"runId"`
+	WorkflowId   string `json:"workflowId,omitempty"`
+	WorkflowName string `json:"workflowName,omitempty"`
+	Origin       string `json:"origin,omitempty"`
+	SourceRef    string `json:"sourceRef,omitempty"`
+	Key          string `json:"key,omitempty"`
+	// State is the derived lifecycle: running | completed | noResult
+	// (models.WorkflowRunState).
+	State string `json:"state"`
+	// Start / End are unix seconds; End is 0 while the run is still open.
+	Start int64 `json:"start,omitempty"`
+	End   int64 `json:"end,omitempty"`
+	// Dispatched / Resolved are the sizes of the run's dispatched and resolved
+	// operation sets, exposed as a coarse progress hint.
+	Dispatched int `json:"dispatched"`
+	Resolved   int `json:"resolved"`
+	// HasResults is true when the run accumulated any stage output.
+	HasResults bool `json:"hasResults"`
+}
+
+// WorkflowRunStatusSummary aggregates a run set by state so a surface can render
+// a headline ("3 running / 1 done") without re-tallying client-side.
+type WorkflowRunStatusSummary struct {
+	Total     int `json:"total"`
+	Running   int `json:"running"`
+	Completed int `json:"completed"`
+	NoResult  int `json:"noResult"`
+}
+
+// GetWorkflowRuns reports the status of the workflow runs launched from a
+// surface. Runs are grouped by the launch's SourceRef (e.g. a case id) and
+// scoped to the caller's organisation; an optional RunIds filter narrows to a
+// specific launch.
+//
+// @Router /tasks/{taskId}/workflow-runs [get]
+type GetWorkflowRunsResponse struct {
+	Runs    []WorkflowRunStatus      `json:"runs"`
+	Summary WorkflowRunStatusSummary `json:"summary"`
+}
+type GetWorkflowRunsSuccessResponse struct {
+	SuccessResponse
+	Data GetWorkflowRunsResponse `json:"data"`
+}
+type GetWorkflowRunsErrorResponse struct {
 	ErrorResponse
 }

--- a/pkg/models/case_media.go
+++ b/pkg/models/case_media.go
@@ -66,6 +66,17 @@ type CaseMedia struct {
 	// matching one of the single-op CaseMediaAction values.
 	Params map[string]interface{} `json:"params,omitempty" bson:"params,omitempty"`
 
+	// OriginAttachmentId marks a Role=source row that was materialised
+	// from a video CaseAttachment (see the case_attachments collection)
+	// so a case's attached videos can flow through the same
+	// workflow-run and redaction machinery as device recordings. It
+	// back-links to the CaseAttachment.Id. Rows carrying it are kept
+	// out of the normal media playlist and default to
+	// IncludeInExport=false / IncludeInShare=false at insert time (the
+	// owning attachment carries its own export/share curation). Only
+	// meaningful on Role = "source".
+	OriginAttachmentId *primitive.ObjectID `json:"originAttachmentId,omitempty" bson:"origin_attachment_id,omitempty"`
+
 	// Source snapshot fields (populated on Role = "source"; mirrored from
 	// Media at attach time so the case stays self-contained even after
 	// the original media document is cleaned up).
@@ -217,7 +228,10 @@ func (cm *CaseMedia) Validate() error {
 
 	switch cm.Role {
 	case CaseMediaRoleSource:
-		if cm.SourceMediaId == nil || cm.SourceMediaId.IsZero() {
+		// Attachment-origin sources are materialised from a
+		// CaseAttachment (no backing Media document), so they identify
+		// themselves via OriginAttachmentId instead of SourceMediaId.
+		if cm.OriginAttachmentId == nil && (cm.SourceMediaId == nil || cm.SourceMediaId.IsZero()) {
 			return fmt.Errorf("case_media: source row requires sourceMediaId")
 		}
 		if cm.VideoFile == "" {

--- a/pkg/models/workflowrun.go
+++ b/pkg/models/workflowrun.go
@@ -22,6 +22,34 @@ const (
 	WorkflowOriginManual WorkflowRunOrigin = "manual"
 )
 
+// WorkflowRunState is the coarse, client-facing lifecycle of a run, derived
+// from the persisted Start/End and the dispatched/resolved operation sets. It
+// is NOT stored on the run — the run carries only the raw lifecycle fields —
+// but computed on read (see WorkflowRun.LifecycleState) so a surface polling a
+// run can render "still working" vs "results are in" without duplicating the
+// derivation. A dedicated "failed" state is intentionally absent: the run
+// document has no failure marker (the engine either finalises a run or leaves
+// it open), so a run that never ends reads as running until a caller-side
+// deadline gives up on it.
+type WorkflowRunState string
+
+const (
+	// WorkflowRunStateRunning is an open run: it has not been finalised (End is
+	// unset), so at least one dispatched stage is still outstanding.
+	WorkflowRunStateRunning WorkflowRunState = "running"
+	// WorkflowRunStateCompleted is a finalised run that produced output: it has
+	// ended and at least one stage resolved (or accumulated Results), so there is
+	// something for the surface to surface.
+	WorkflowRunStateCompleted WorkflowRunState = "completed"
+	// WorkflowRunStateNoResult is a finalised run that produced nothing: it ended
+	// having dispatched and resolved no stages. This is the visible face of the
+	// silent no-op — a conditional workflow whose gates matched nothing, or a
+	// workflow the engine could not dispatch (e.g. a user/DB workflow absent from
+	// its registry) — so a surface can say "completed, no results" rather than
+	// implying success.
+	WorkflowRunStateNoResult WorkflowRunState = "noResult"
+)
+
 // WorkflowRun is the single type the workflow subsystem uses for a run, in both
 // of its representations:
 //
@@ -286,6 +314,35 @@ func (r WorkflowRun) MarshalJSON() ([]byte, error) {
 		w.RunId = r.Id.Hex()
 	}
 	return json.Marshal(w)
+}
+
+// LifecycleState derives the coarse, client-facing run state from the raw
+// persisted lifecycle fields (Start/End and the dispatched/resolved sets). It
+// is the single source of truth for "is this run still working, done, or done
+// with nothing to show" so every surface reading a run agrees on the meaning
+// without re-implementing the rule:
+//
+//   - End == 0                                  -> running   (not finalised)
+//   - End > 0 && (resolved>0 || Results present) -> completed (finalised, produced)
+//   - End > 0 && dispatched==0 && resolved==0    -> noResult  (finalised, no-op)
+//
+// The lifecycle fields are persistence-only (json:"-"), so this is meant to run
+// server-side against a decoded run document; the derived state is what crosses
+// the wire.
+func (r WorkflowRun) LifecycleState() WorkflowRunState {
+	if r.End == 0 {
+		return WorkflowRunStateRunning
+	}
+	if len(r.ResolvedOperations) > 0 || len(r.Results) > 0 {
+		return WorkflowRunStateCompleted
+	}
+	if len(r.DispatchedOperations) == 0 {
+		return WorkflowRunStateNoResult
+	}
+	// Finalised with stages dispatched but none recorded as resolved. The engine
+	// only ends a run once every dispatched op resolves, so this is not expected
+	// in practice; treat it as completed (work was done) rather than no-op.
+	return WorkflowRunStateCompleted
 }
 
 // AutomaticRunObjectID derives the DETERMINISTIC run identity for an automatic


### PR DESCRIPTION
## Description

This PR expands workflow and media-processing support for attachment-origin videos while adding a dedicated workflow-run status API for clients polling execution progress.

Previously, workflows and redaction flows primarily operated on device-backed case media. Video attachments required separate handling and could not reliably participate in the same lifecycle. This change introduces attachment-origin `CaseMedia` rows that are materialised on demand from `CaseAttachment` records, allowing attached videos to flow through existing workflow execution and media edit pipelines without requiring migrations or duplicated logic.

The update also adds support for launching workflows directly against attachment IDs, making workflow execution consistent regardless of whether the source media originated from a recording device or an uploaded attachment. By treating both sources uniformly, the workflow subsystem becomes easier to maintain and surfaces gain a simpler integration model.

On the API side, this PR introduces workflow-run status retrieval endpoints and a derived lifecycle state model (`running`, `completed`, `noResult`). This gives clients a stable, surface-agnostic way to monitor workflow progress and outcomes without needing to reconstruct state from low-level persistence fields. The summary payloads also reduce client-side aggregation work and make it easier to render real-time workflow activity in the UI.

Overall, these changes improve workflow observability, reduce fragmentation between media source types, and enable attachment-based videos to participate fully in automation and redaction features using the same infrastructure as existing case media.