### PR TITLE
add FPS to VaultMediaMetadata

### DIFF
--- a/pkg/models/media.go
+++ b/pkg/models/media.go
@@ -158,6 +158,7 @@ type VaultMediaMetadata struct {
 	IsFragmented     bool                         `json:"is_fragmented" bson:"is_fragmented"`
 	Duration         uint64                       `json:"duration" bson:"duration"`
 	Timescale        uint32                       `json:"timescale" bson:"timescale"`
+	FPS              int                          `json:"fps" bson:"fps"` // frames per second, derived from the parsed MP4 samples
 }
 
 type VaultMediaEvent struct {


### PR DESCRIPTION
## Description

This change adds an `FPS` field to `VaultMediaMetadata` to expose the frame rate of parsed MP4 media directly in the stored metadata.

Including FPS as part of the media model makes video metadata more complete and immediately usable for downstream consumers without requiring additional parsing or computation at read time. This improves support for features that depend on playback characteristics, such as media validation, transcoding decisions, analytics, or UI presentation.

The value is derived from parsed MP4 samples, ensuring the metadata reflects the actual media content rather than relying on external assumptions or client-side calculations.