### PR TITLE
feat(videowall): add shareable Layout and AllowLayoutEdits fields

### DIFF
--- a/pkg/models/videowall.go
+++ b/pkg/models/videowall.go
@@ -32,6 +32,29 @@ type Videowall struct {
 	// "preview" (SD) or "live" (HD). Empty defaults to "live". Always clamped
 	// to "preview" when Liveview only grants preview permission.
 	DefaultViewingMode string `json:"default_viewing_mode" bson:"default_viewing_mode,omitempty"`
+	// Layout stores a shareable custom arrangement of the wall's camera tiles
+	// (order + per-tile column/row spans). When nil the wall falls back to the
+	// default responsive grid. It travels with the wall so it is shared with
+	// everyone the wall is shared with.
+	Layout *VideowallLayout `json:"layout,omitempty" bson:"layout,omitempty"`
+	// AllowLayoutEdits lets any signed-in viewer (not just the owner) persist
+	// changes to Layout. When false only the owner may save.
+	AllowLayoutEdits bool `json:"allow_layout_edits" bson:"allow_layout_edits"`
+}
+
+// VideowallLayout is the persisted, shareable tile arrangement of a videowall.
+type VideowallLayout struct {
+	// Columns is the grid column count the layout was authored against (1-5).
+	Columns int `json:"columns" bson:"columns"`
+	// Tiles lists each placed camera in display order with its span.
+	Tiles []VideowallLayoutTile `json:"tiles" bson:"tiles"`
+}
+
+// VideowallLayoutTile is a single camera's position and size within a layout.
+type VideowallLayoutTile struct {
+	CameraKey string `json:"cameraKey" bson:"cameraKey"`
+	ColSpan   int    `json:"colSpan" bson:"colSpan"`
+	RowSpan   int    `json:"rowSpan" bson:"rowSpan"`
 }
 
 // IsScheduledAt reports whether unixTs falls within the videowall's weekly

--- a/pkg/properties/videowall.go
+++ b/pkg/properties/videowall.go
@@ -26,4 +26,19 @@ const (
 	VideowallAssignedUsers = "assigned_users"
 	VideowallWeeklySchedule = "weeklySchedule"
 	VideowallDefaultViewingMode = "default_viewing_mode"
+	VideowallLayout = "layout"
+	VideowallAllowLayoutEdits = "allow_layout_edits"
+)
+
+// VideowallLayout property field names (BSON)
+const (
+	VideowallLayoutColumns = "columns"
+	VideowallLayoutTiles = "tiles"
+)
+
+// VideowallLayoutTile property field names (BSON)
+const (
+	VideowallLayoutTileCameraKey = "cameraKey"
+	VideowallLayoutTileColSpan = "colSpan"
+	VideowallLayoutTileRowSpan = "rowSpan"
 )


### PR DESCRIPTION
## Description

This change adds persisted, shareable videowall layouts so camera arrangements can be saved and reused across sessions and users. Until now, videowalls relied on the default responsive grid, which made custom layouts temporary and user-specific.

By introducing the `Layout` field, videowalls can now store tile ordering and sizing information directly with the wall itself. This improves collaboration and consistency, since shared walls now preserve the intended viewing experience for everyone with access.

The new `AllowLayoutEdits` field adds control over how collaborative these layouts are. Owners can choose whether viewers are allowed to persist layout changes, enabling both locked-down operational walls and collaborative editing workflows without requiring separate wall ownership.

The addition of explicit layout and tile property definitions also standardizes serialization and persistence across JSON/BSON boundaries, making the model easier to maintain and extend in future layout-related features.