### PR TITLE
Feat/redaction request organisation

### DIFF
--- a/pkg/api/analysis.go
+++ b/pkg/api/analysis.go
@@ -365,8 +365,14 @@ func (fs FlexibleString) String() string {
 // exactly where to upload the rendered artefact so the storage layout
 // stays under hub-api's control.
 type SubmitFaceRedactionRequest struct {
-	AnalysisId          string                        `json:"analysisId"`
-	TaskId              string                        `json:"taskId"`
+	AnalysisId string `json:"analysisId"`
+	TaskId     string `json:"taskId"`
+	// OrganisationId scopes the redaction job to the owning organisation. It is
+	// carried on the request struct itself (not only on the transport envelope)
+	// so the worker can resolve the same Request whether the struct arrives on an
+	// on-demand PipelineEvent (event.Payload) or a hub-workflows stage dispatch
+	// (run.User) — i.e. the request is self-contained and transport agnostic.
+	OrganisationId      string                        `json:"organisationId,omitempty"`
 	CaseMediaId         string                        `json:"caseMediaId"`
 	SignedUrl           string                        `json:"signedUrl"`
 	FileName            string                        `json:"fileName"`

--- a/pkg/models/videowall.go
+++ b/pkg/models/videowall.go
@@ -32,6 +32,29 @@ type Videowall struct {
 	// "preview" (SD) or "live" (HD). Empty defaults to "live". Always clamped
 	// to "preview" when Liveview only grants preview permission.
 	DefaultViewingMode string `json:"default_viewing_mode" bson:"default_viewing_mode,omitempty"`
+	// Layout stores a shareable custom arrangement of the wall's camera tiles
+	// (order + per-tile column/row spans). When nil the wall falls back to the
+	// default responsive grid. It travels with the wall so it is shared with
+	// everyone the wall is shared with.
+	Layout *VideowallLayout `json:"layout,omitempty" bson:"layout,omitempty"`
+	// AllowLayoutEdits lets any signed-in viewer (not just the owner) persist
+	// changes to Layout. When false only the owner may save.
+	AllowLayoutEdits bool `json:"allow_layout_edits" bson:"allow_layout_edits"`
+}
+
+// VideowallLayout is the persisted, shareable tile arrangement of a videowall.
+type VideowallLayout struct {
+	// Columns is the grid column count the layout was authored against (1-5).
+	Columns int `json:"columns" bson:"columns"`
+	// Tiles lists each placed camera in display order with its span.
+	Tiles []VideowallLayoutTile `json:"tiles" bson:"tiles"`
+}
+
+// VideowallLayoutTile is a single camera's position and size within a layout.
+type VideowallLayoutTile struct {
+	CameraKey string `json:"cameraKey" bson:"cameraKey"`
+	ColSpan   int    `json:"colSpan" bson:"colSpan"`
+	RowSpan   int    `json:"rowSpan" bson:"rowSpan"`
 }
 
 // IsScheduledAt reports whether unixTs falls within the videowall's weekly

--- a/pkg/properties/videowall.go
+++ b/pkg/properties/videowall.go
@@ -26,4 +26,19 @@ const (
 	VideowallAssignedUsers = "assigned_users"
 	VideowallWeeklySchedule = "weeklySchedule"
 	VideowallDefaultViewingMode = "default_viewing_mode"
+	VideowallLayout = "layout"
+	VideowallAllowLayoutEdits = "allow_layout_edits"
+)
+
+// VideowallLayout property field names (BSON)
+const (
+	VideowallLayoutColumns = "columns"
+	VideowallLayoutTiles = "tiles"
+)
+
+// VideowallLayoutTile property field names (BSON)
+const (
+	VideowallLayoutTileCameraKey = "cameraKey"
+	VideowallLayoutTileColSpan = "colSpan"
+	VideowallLayoutTileRowSpan = "rowSpan"
 )


### PR DESCRIPTION
## Description

This change makes face redaction requests self-contained by adding `OrganisationId` directly to `SubmitFaceRedactionRequest`. Previously, organisation scoping depended on transport-specific metadata, which made request handling inconsistent across pipeline events and workflow dispatches. Embedding the organisation context in the request itself ensures workers can process jobs reliably regardless of how they are delivered, reducing coupling to transport details and improving portability across execution paths.

The PR also introduces persisted videowall layout support. Videowalls can now store and share custom camera arrangements, including tile ordering and per-tile sizing, instead of relying solely on the default responsive grid. This improves collaboration by allowing shared walls to preserve a consistent viewing experience for all users.

In addition, layout editing permissions are now configurable through `AllowLayoutEdits`, enabling organisations to control whether shared viewers can persist layout changes or restrict that capability to owners only. Supporting BSON property constants alongside the new models keeps persistence logic aligned and avoids hardcoded field usage across the codebase.