### PR TITLE
feat(organisation): add OrganisationUpdate patch DTO for partial updates

### DIFF
--- a/pkg/api/organisation.go
+++ b/pkg/api/organisation.go
@@ -113,10 +113,11 @@ type CreateOrganisationErrorResponse struct {
 	ErrorResponse
 }
 
-// UpdateOrganisation applies a partial update.
+// UpdateOrganisation applies a partial update. The body is an OrganisationUpdate
+// patch: only the fields present are changed (each field is optional).
 // @Router /organisations/{id} [patch]
 type UpdateOrganisationRequest struct {
-	Organisation models.Organisation `json:"organisation"`
+	Organisation models.OrganisationUpdate `json:"organisation"`
 }
 type UpdateOrganisationResponse struct {
 	Organisation models.Organisation `json:"organisation"`

--- a/pkg/models/organisation.go
+++ b/pkg/models/organisation.go
@@ -220,13 +220,30 @@ type CreateOrganisationOutput struct {
 	Organisation *Organisation `json:"organisation"`
 }
 
+// OrganisationUpdate is a partial-update (PATCH) payload for an organisation.
+// Every field is a pointer so a nil value means "not provided" (leave the stored
+// value untouched), which is distinct from an explicit zero value (e.g. clearing
+// a string or setting IsActive to false). Identity, ownership and audit fields
+// are intentionally absent because they are managed server-side.
+type OrganisationUpdate struct {
+	Name           *string               `json:"name,omitempty"`
+	Slug           *string               `json:"slug,omitempty"`
+	Description    *string               `json:"description,omitempty"`
+	Domain         *string               `json:"domain,omitempty"`
+	IsActive       *bool                 `json:"isActive,omitempty"`
+	Settings       *OrganisationSettings `json:"settings,omitempty"`
+	Company        *CompanyDetails       `json:"company,omitempty"`
+	Subscription   *Subscription         `json:"subscription,omitempty"`
+	BillingAddress *Address              `json:"billingAddress,omitempty"`
+}
+
 // UpdateOrganisationInput applies a partial update to an organisation the caller
-// is allowed to modify. Only a whitelisted set of profile/settings fields is
-// applied by the repository; ownership and audit stamps are managed server-side.
+// is allowed to modify. Only the fields set on the OrganisationUpdate payload
+// are changed; ownership and audit stamps are managed server-side.
 type UpdateOrganisationInput struct {
-	User           User         `json:"user"`
-	OrganisationId string       `json:"organisationId"`
-	Organisation   Organisation `json:"organisation"`
+	User           User               `json:"user"`
+	OrganisationId string             `json:"organisationId"`
+	Organisation   OrganisationUpdate `json:"organisation"`
 }
 
 type UpdateOrganisationOutput struct {

--- a/src/typescript/types.ts
+++ b/src/typescript/types.ts
@@ -19192,6 +19192,45 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/internal/organisationupdate": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get OrganisationUpdate (schema generation only)
+         * @description Internal endpoint used only to ensure OrganisationUpdate schema is generated in OpenAPI spec
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["models.OrganisationUpdate"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/internal/organisationuser": {
         parameters: {
             query?: never;
@@ -26485,6 +26524,84 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/internal/videowalllayout": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get VideowallLayout (schema generation only)
+         * @description Internal endpoint used only to ensure VideowallLayout schema is generated in OpenAPI spec
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["models.VideowallLayout"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/internal/videowalllayouttile": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get VideowallLayoutTile (schema generation only)
+         * @description Internal endpoint used only to ensure VideowallLayoutTile schema is generated in OpenAPI spec
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["models.VideowallLayoutTile"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/internal/warningresponse": {
         parameters: {
             query?: never;
@@ -30323,6 +30440,12 @@ export interface components {
             faceRedaction?: components["schemas"]["models.FaceRedaction"];
             fileName?: string;
             mode?: components["schemas"]["models.RedactionMode"];
+            /** @description OrganisationId scopes the redaction job to the owning organisation. It is
+             *     carried on the request struct itself (not only on the transport envelope)
+             *     so the worker can resolve the same Request whether the struct arrives on an
+             *     on-demand PipelineEvent (event.Payload) or a hub-workflows stage dispatch
+             *     (run.User) — i.e. the request is self-contained and transport agnostic. */
+            organisationId?: string;
             signedUrl?: string;
             taskId?: string;
         };
@@ -30756,7 +30879,7 @@ export interface components {
             metadata?: components["schemas"]["api.Metadata"];
         };
         "api.UpdateOrganisationRequest": {
-            organisation?: components["schemas"]["models.Organisation"];
+            organisation?: components["schemas"]["models.OrganisationUpdate"];
         };
         "api.UpdateOrganisationResponse": {
             organisation?: components["schemas"]["models.Organisation"];
@@ -33122,6 +33245,17 @@ export interface components {
              *     and billing. */
             timezone?: string;
         };
+        "models.OrganisationUpdate": {
+            billingAddress?: components["schemas"]["models.Address"];
+            company?: components["schemas"]["models.CompanyDetails"];
+            description?: string;
+            domain?: string;
+            isActive?: boolean;
+            name?: string;
+            settings?: components["schemas"]["models.OrganisationSettings"];
+            slug?: string;
+            subscription?: components["schemas"]["models.Subscription"];
+        };
         "models.OrganisationUser": {
             audit?: components["schemas"]["models.Audit"];
             /** @description ExpiresAt optionally bounds the membership in time. It is an overlay on
@@ -33885,7 +34019,7 @@ export interface components {
         };
         "models.UpdateCaseShareOTPOutput": Record<string, never>;
         "models.UpdateOrganisationInput": {
-            organisation?: components["schemas"]["models.Organisation"];
+            organisation?: components["schemas"]["models.OrganisationUpdate"];
             organisationId?: string;
             user?: components["schemas"]["models.User"];
         };
@@ -34129,6 +34263,9 @@ export interface components {
             time?: string;
         };
         "models.Videowall": {
+            /** @description AllowLayoutEdits lets any signed-in viewer (not just the owner) persist
+             *     changes to Layout. When false only the owner may save. */
+            allow_layout_edits?: boolean;
             assigned_users?: string[];
             cameras?: string[];
             /** @description DefaultViewingMode chooses which stream quality the wall loads with:
@@ -34143,6 +34280,11 @@ export interface components {
             id?: string;
             io?: number;
             isActive?: number;
+            /** @description Layout stores a shareable custom arrangement of the wall's camera tiles
+             *     (order + per-tile column/row spans). When nil the wall falls back to the
+             *     default responsive grid. It travels with the wall so it is shared with
+             *     everyone the wall is shared with. */
+            layout?: components["schemas"]["models.VideowallLayout"];
             liveview?: number;
             master_user_id?: string;
             name?: string;
@@ -34154,6 +34296,17 @@ export interface components {
             user_id?: string;
             username?: string;
             weeklySchedule?: components["schemas"]["models.WeeklySchedule"][];
+        };
+        "models.VideowallLayout": {
+            /** @description Columns is the grid column count the layout was authored against (1-5). */
+            columns?: number;
+            /** @description Tiles lists each placed camera in display order with its span. */
+            tiles?: components["schemas"]["models.VideowallLayoutTile"][];
+        };
+        "models.VideowallLayoutTile": {
+            cameraKey?: string;
+            colSpan?: number;
+            rowSpan?: number;
         };
         "models.Webhook": {
             enabled?: boolean;
@@ -34720,6 +34873,7 @@ export namespace models {
     export type OrganisationInvitation = components['schemas']['models.OrganisationInvitation'];
     export type OrganisationMember = components['schemas']['models.OrganisationMember'];
     export type OrganisationSettings = components['schemas']['models.OrganisationSettings'];
+    export type OrganisationUpdate = components['schemas']['models.OrganisationUpdate'];
     export type OrganisationUser = components['schemas']['models.OrganisationUser'];
     export type OrganisationUserDetails = components['schemas']['models.OrganisationUserDetails'];
     export type PatchVideowallInput = components['schemas']['models.PatchVideowallInput'];
@@ -34800,6 +34954,8 @@ export namespace models {
     export type VaultMediaMetadata = components['schemas']['models.VaultMediaMetadata'];
     export type VideoBytesRangeOnTime = components['schemas']['models.VideoBytesRangeOnTime'];
     export type Videowall = components['schemas']['models.Videowall'];
+    export type VideowallLayout = components['schemas']['models.VideowallLayout'];
+    export type VideowallLayoutTile = components['schemas']['models.VideowallLayoutTile'];
     export type Webhook = components['schemas']['models.Webhook'];
     export type WeeklySchedule = components['schemas']['models.WeeklySchedule'];
     export type Workflow = components['schemas']['models.Workflow'];


### PR DESCRIPTION
## Description

This change introduces a dedicated `OrganisationUpdate` DTO for PATCH operations, making partial organisation updates explicit and safer.

Previously, the update endpoint reused the full `Organisation` model, which blurred the distinction between complete replacements and partial updates. That made it difficult to reliably tell whether a field was intentionally set to a zero value or simply omitted from the request.

The new `OrganisationUpdate` type solves this by using pointer fields for all updatable properties. This allows the API to clearly differentiate between:
- fields that should remain unchanged (`nil`)
- fields intentionally updated to empty or false values

This improves update semantics, reduces the risk of accidental data overwrites, and aligns the API behavior with standard PATCH expectations.

The PR also updates the generated OpenAPI and TypeScript schemas so client applications can correctly model optional patch fields and benefit from stronger typing when performing partial updates.