### PR TITLE
feat: add active organisation contracts

### DIFF
--- a/pkg/api/organisation.go
+++ b/pkg/api/organisation.go
@@ -97,6 +97,22 @@ type GetOrganisationErrorResponse struct {
 	ErrorResponse
 }
 
+// SetCurrentOrganisation selects the active organisation for the caller.
+// @Router /organisations/current [patch]
+type SetCurrentOrganisationRequest struct {
+	OrganisationId string `json:"organisationId"`
+}
+type SetCurrentOrganisationResponse struct {
+	Organisation models.Organisation `json:"organisation"`
+}
+type SetCurrentOrganisationSuccessResponse struct {
+	SuccessResponse
+	Data SetCurrentOrganisationResponse `json:"data"`
+}
+type SetCurrentOrganisationErrorResponse struct {
+	ErrorResponse
+}
+
 // CreateOrganisation
 // @Router /organisations [post]
 type CreateOrganisationRequest struct {

--- a/pkg/models/organisation.go
+++ b/pkg/models/organisation.go
@@ -210,6 +210,17 @@ type GetCurrentOrganisationOutput struct {
 	Organisation *Organisation `json:"organisation"`
 }
 
+// SetCurrentOrganisationInput selects the organisation used to scope subsequent
+// requests for the caller.
+type SetCurrentOrganisationInput struct {
+	User           User   `json:"user"`
+	OrganisationId string `json:"organisationId"`
+}
+
+type SetCurrentOrganisationOutput struct {
+	Organisation *Organisation `json:"organisation"`
+}
+
 // CreateOrganisationInput creates a new organisation owned by the caller.
 type CreateOrganisationInput struct {
 	User         User         `json:"user"`

--- a/pkg/models/user.go
+++ b/pkg/models/user.go
@@ -28,12 +28,16 @@ func GetOrganisationId(user User) string {
 	return GetOrganisationObjectId(user).Hex()
 }
 
-// GetOrganisationObjectId returns the organisation id as a primitive.ObjectID.
-// The organisation id is the master account's _id (or the user's own _id when
-// they are not a sub-user). The nil check on Master guards against a populated
-// MasterAccount string without a hydrated Master document, avoiding a panic.
+// GetOrganisationObjectId returns the user's explicitly selected organisation,
+// falling back to the legacy master-account identity for unmigrated users.
 func GetOrganisationObjectId(user User) primitive.ObjectID {
-	if user.MasterAccount != "" && !user.Master.Id.IsZero() {
+	if !user.OrganisationId.IsZero() {
+		return user.OrganisationId
+	}
+	if user.MasterAccount != "" && user.Master != nil && !user.Master.Id.IsZero() {
+		if !user.Master.OrganisationId.IsZero() {
+			return user.Master.OrganisationId
+		}
 		return user.Master.Id
 	}
 	return user.Id

--- a/pkg/models/user_test.go
+++ b/pkg/models/user_test.go
@@ -1,0 +1,44 @@
+package models
+
+import (
+	"testing"
+
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+func TestGetOrganisationObjectIdPrefersExplicitOrganisation(t *testing.T) {
+	activeOrganisationId := primitive.NewObjectID()
+	masterId := primitive.NewObjectID()
+	user := User{
+		Id:             primitive.NewObjectID(),
+		OrganisationId: activeOrganisationId,
+		MasterAccount:  masterId.Hex(),
+		Master:         &User{Id: masterId},
+	}
+
+	if got := GetOrganisationObjectId(user); got != activeOrganisationId {
+		t.Fatalf("organisation id = %s, want %s", got.Hex(), activeOrganisationId.Hex())
+	}
+}
+
+func TestGetOrganisationObjectIdFallsBackToMaster(t *testing.T) {
+	masterId := primitive.NewObjectID()
+	user := User{
+		Id:            primitive.NewObjectID(),
+		MasterAccount: masterId.Hex(),
+		Master:        &User{Id: masterId},
+	}
+
+	if got := GetOrganisationObjectId(user); got != masterId {
+		t.Fatalf("organisation id = %s, want %s", got.Hex(), masterId.Hex())
+	}
+}
+
+func TestGetOrganisationObjectIdHandlesUnhydratedMaster(t *testing.T) {
+	userId := primitive.NewObjectID()
+	user := User{Id: userId, MasterAccount: primitive.NewObjectID().Hex()}
+
+	if got := GetOrganisationObjectId(user); got != userId {
+		t.Fatalf("organisation id = %s, want %s", got.Hex(), userId.Hex())
+	}
+}


### PR DESCRIPTION
## Description

This change introduces support for explicitly selecting and tracking the active organisation for a user, rather than implicitly deriving organisation context from the legacy master-account relationship.

The main motivation is to make organisation scoping predictable and flexible for multi-organisation users. By allowing callers to set a current organisation, subsequent requests can operate against the intended organisation context without relying on historical account assumptions.

Key improvements include:
- Added API contracts for selecting the current organisation via `/organisations/current`.
- Introduced dedicated input/output models for setting the active organisation.
- Updated organisation resolution logic to prioritise an explicitly selected `OrganisationId`.
- Preserved backwards compatibility by falling back to the legacy master-account behaviour for unmigrated users.
- Hardened the lookup logic against nil or unhydrated master references to avoid runtime panics.
- Added unit tests covering explicit organisation selection, legacy fallback behaviour, and edge cases.

This lays the groundwork for cleaner multi-tenant behaviour while maintaining compatibility with existing users and flows.