### PR TITLE
feat(media): add MarkerSummary for per-occurrence marker detail

### DIFF
--- a/pkg/models/media.go
+++ b/pkg/models/media.go
@@ -43,6 +43,13 @@ type Media struct {
 	TagNames      []string `json:"tagNames,omitempty" bson:"tagNames,omitempty"`
 	CategoryNames []string `json:"categoryNames,omitempty" bson:"categoryNames,omitempty"`
 
+	// MarkerSummary is a per-occurrence denormalisation of the markers that overlap
+	// this media. Unlike the flat markerNames/eventNames/tagNames/categoryNames
+	// arrays that back filtering, each entry preserves the correlation between a
+	// single marker's name, its category/event/tag names and its time range, for
+	// display/detail rendering (icons, listings).
+	MarkerSummary []MarkerSummary `json:"markerSummary,omitempty" bson:"markerSummary,omitempty"`
+
 	// Name of the device that uploaded media
 	DeviceName string `json:"deviceName,omitempty" bson:"deviceName,omitempty"`
 
@@ -56,6 +63,19 @@ type Media struct {
 
 	// Audit information
 	Audit *Audit `json:"audit,omitempty" bson:"audit,omitempty"`
+}
+
+// MarkerSummary captures a single marker occurrence denormalised onto a media
+// document. It is written (append-only, bounded) alongside the flat name arrays
+// so the frontend can render per-marker detail (name, categories, events, tags)
+// and the marker's time range without a second query.
+type MarkerSummary struct {
+	Name           string   `json:"name,omitempty" bson:"name,omitempty"`
+	CategoryNames  []string `json:"categoryNames,omitempty" bson:"categoryNames,omitempty"`
+	EventNames     []string `json:"eventNames,omitempty" bson:"eventNames,omitempty"`
+	TagNames       []string `json:"tagNames,omitempty" bson:"tagNames,omitempty"`
+	StartTimestamp int64    `json:"startTimestamp,omitempty" bson:"startTimestamp,omitempty"`
+	EndTimestamp   int64    `json:"endTimestamp,omitempty" bson:"endTimestamp,omitempty"`
 }
 
 // We can store additional metadata for media files, such as tags and classifications.

--- a/pkg/properties/media.go
+++ b/pkg/properties/media.go
@@ -55,6 +55,7 @@ const (
 	MediaEventNames            = "eventNames"
 	MediaTagNames              = "tagNames"
 	MediaCategoryNames         = "categoryNames"
+	MediaMarkerSummary         = "markerSummary"
 	MediaDeviceName            = "deviceName"
 	MediaMetadata              = "metadata"
 	MediaAtRuntimeMetadata     = "atRuntimeMetadata"

--- a/src/typescript/types.ts
+++ b/src/typescript/types.ts
@@ -32939,6 +32939,14 @@ export interface components {
             device?: components["schemas"]["models.Device"];
             markers?: components["schemas"]["models.MarkerGroup"][];
         };
+        "models.MarkerSummary": {
+            name?: string;
+            categoryNames?: string[];
+            eventNames?: string[];
+            tagNames?: string[];
+            startTimestamp?: number;
+            endTimestamp?: number;
+        };
         "models.Media": {
             /** @description AtRuntimeMetadata contains metadata that is generated at runtime, which can include
              *     more verbose information about the device's current state, capabilities, or configuration.
@@ -32964,6 +32972,7 @@ export interface components {
             /** @description Unique identifier for the media file */
             id?: string;
             markerNames?: string[];
+            markerSummary?: components["schemas"]["models.MarkerSummary"][];
             /** @description Metadata */
             metadata?: components["schemas"]["models.MediaMetadata"];
             organisationId?: string;


### PR DESCRIPTION
## Description

This change adds `MarkerSummary` to media documents to preserve per-marker context that is currently lost in the flattened `markerNames`, `eventNames`, `tagNames`, and `categoryNames` arrays.

Today, media filtering works because marker-related fields are denormalised into flat lists, but that structure does not retain the relationship between a specific marker occurrence and its associated categories, events, tags, or time range. As a result, the frontend cannot reliably render detailed marker information without performing additional queries or reconstructing correlations client-side.

`MarkerSummary` addresses this by storing a bounded per-occurrence summary directly on the media document, including:
- marker name
- associated categories, events, and tags
- start and end timestamps

This improves the project by:
- enabling richer media detail rendering without extra lookups
- preserving marker relationships that flat arrays cannot represent
- reducing frontend complexity and query overhead
- keeping existing filtering behaviour intact while extending the API with structured marker metadata

The change also updates shared property definitions and generated TypeScript types so the new field is consistently available across backend and frontend code paths.