### PR TITLE
feat(workflow): add redaction trigger surface

### DIFF
--- a/pkg/models/workflow.go
+++ b/pkg/models/workflow.go
@@ -94,6 +94,14 @@ const (
 	WorkflowSurfaceCase WorkflowTriggerSurface = "case"
 	// WorkflowSurfaceMedia exposes a manual trigger on an individual media item.
 	WorkflowSurfaceMedia WorkflowTriggerSurface = "media"
+	// WorkflowSurfaceRedaction exposes a manual trigger on the redaction editor's
+	// submit control, launched against the media being redacted. It is a distinct
+	// launch point from the generic case/media "Run workflow" surfaces: a workflow
+	// opts in to it (typically a detector→redaction graph, e.g. objecttracking →
+	// redaction) so the editor lists the applicable workflows purely as data,
+	// without a hard-coded workflow id. The reviewed inline-regions submit stays a
+	// private one-stage run and does not use this surface.
+	WorkflowSurfaceRedaction WorkflowTriggerSurface = "redaction"
 )
 
 // WorkflowTrigger defines what activates a workflow. Type selects the activation

--- a/src/typescript/types.ts
+++ b/src/typescript/types.ts
@@ -34689,7 +34689,7 @@ export interface components {
             weeklySchedule?: components["schemas"]["models.WeeklySchedule"][];
         };
         /** @enum {string} */
-        "models.WorkflowTriggerSurface": "case" | "media";
+        "models.WorkflowTriggerSurface": "case" | "media" | "redaction";
         /** @enum {string} */
         "models.WorkflowTriggerType": "automatic" | "manual";
         "models.WorkflowUser": {


### PR DESCRIPTION
## Description

This change introduces a dedicated `redaction` workflow trigger surface, allowing workflows to explicitly opt into execution from the redaction editor submit flow.

Previously, workflows launched from redaction flows would need to rely on generic `case` or `media` trigger surfaces, making the integration ambiguous and forcing workflow selection logic to depend on hard-coded workflow identifiers. By introducing a distinct `redaction` surface, the editor can now discover and present applicable workflows purely through workflow metadata and configuration.

This improves the workflow system in a few important ways:
- Enables cleaner detector → redaction workflow chains without coupling the UI to specific workflow IDs.
- Makes workflow trigger intent explicit and easier to reason about.
- Keeps redaction-specific execution paths isolated from broader case/media workflow surfaces.
- Improves extensibility for future redaction-integrated workflows.

The TypeScript API types were updated accordingly so frontend consumers recognize and support the new trigger surface consistently.