### PR TITLE
Fix fractional recording FPS preservation

### DIFF
--- a/models.puml
+++ b/models.puml
@@ -592,7 +592,7 @@ namespace models {
         + Resolution string
         + Codec string
         + Bitrate int
-        + FPS int
+        + FPS float64
         + Tags []string
         + SpriteInterval int
         + AnalysisId string

--- a/pkg/models/media.go
+++ b/pkg/models/media.go
@@ -81,14 +81,14 @@ type MarkerSummary struct {
 // We can store additional metadata for media files, such as tags and classifications.
 type MediaMetadata struct {
 	// Media containers related information
-	Container  string `json:"containerType,omitempty" bson:"containerType,omitempty"` // e.g., mp4, mkv, avi
-	Resolution string `json:"resolution,omitempty" bson:"resolution,omitempty"`       // e.g., 1920x1080
-	Width      int    `json:"width,omitempty" bson:"width,omitempty"`                 // in pixels
-	Height     int    `json:"height,omitempty" bson:"height,omitempty"`               // in pixels
-	Codec      string `json:"codec,omitempty" bson:"codec,omitempty"`                 // e.g., H.264, VP9
-	Bitrate    int    `json:"bitrate,omitempty" bson:"bitrate,omitempty"`             // in kbps
-	FPS        int    `json:"fps,omitempty" bson:"fps,omitempty"`                     // frames per second
-	FileSize   int64  `json:"fileSize,omitempty" bson:"fileSize,omitempty"`           // in bytes
+	Container  string  `json:"containerType,omitempty" bson:"containerType,omitempty"` // e.g., mp4, mkv, avi
+	Resolution string  `json:"resolution,omitempty" bson:"resolution,omitempty"`       // e.g., 1920x1080
+	Width      int     `json:"width,omitempty" bson:"width,omitempty"`                 // in pixels
+	Height     int     `json:"height,omitempty" bson:"height,omitempty"`               // in pixels
+	Codec      string  `json:"codec,omitempty" bson:"codec,omitempty"`                 // e.g., H.264, VP9
+	Bitrate    int     `json:"bitrate,omitempty" bson:"bitrate,omitempty"`             // in kbps
+	FPS        float64 `json:"fps,omitempty" bson:"fps,omitempty"`                     // frames per second
+	FileSize   int64   `json:"fileSize,omitempty" bson:"fileSize,omitempty"`           // in bytes
 
 	// Tags associated to give some context about the media file
 	Tags []string `json:"tags,omitempty" bson:"tags,omitempty"`
@@ -179,7 +179,7 @@ type VaultMediaMetadata struct {
 	IsFragmented     bool                         `json:"is_fragmented" bson:"is_fragmented"`
 	Duration         uint64                       `json:"duration" bson:"duration"`
 	Timescale        uint32                       `json:"timescale" bson:"timescale"`
-	FPS              int                          `json:"fps" bson:"fps"` // frames per second, derived from the parsed MP4 samples
+	FPS              float64                      `json:"fps" bson:"fps"` // frames per second, derived from the parsed MP4 samples
 }
 
 type VaultMediaEvent struct {

--- a/pkg/models/media_test.go
+++ b/pkg/models/media_test.go
@@ -1,0 +1,46 @@
+package models
+
+import (
+	"encoding/json"
+	"testing"
+
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+func TestMediaMetadataFPSAcceptsHistoricalIntegers(t *testing.T) {
+	var fromJSON MediaMetadata
+	if err := json.Unmarshal([]byte(`{"fps":18}`), &fromJSON); err != nil {
+		t.Fatalf("decode integer JSON FPS: %v", err)
+	}
+	if fromJSON.FPS != 18 {
+		t.Fatalf("integer JSON FPS = %v, want 18", fromJSON.FPS)
+	}
+
+	encoded, err := bson.Marshal(bson.M{"fps": int32(18)})
+	if err != nil {
+		t.Fatalf("encode historical BSON FPS: %v", err)
+	}
+	var fromBSON MediaMetadata
+	if err := bson.Unmarshal(encoded, &fromBSON); err != nil {
+		t.Fatalf("decode historical integer BSON FPS: %v", err)
+	}
+	if fromBSON.FPS != 18 {
+		t.Fatalf("historical BSON FPS = %v, want 18", fromBSON.FPS)
+	}
+}
+
+func TestMediaMetadataFPSPreservesFraction(t *testing.T) {
+	const want = 17.35
+
+	encoded, err := bson.Marshal(MediaMetadata{FPS: want})
+	if err != nil {
+		t.Fatalf("encode fractional BSON FPS: %v", err)
+	}
+	var decoded MediaMetadata
+	if err := bson.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatalf("decode fractional BSON FPS: %v", err)
+	}
+	if decoded.FPS != want {
+		t.Fatalf("fractional BSON FPS = %v, want %v", decoded.FPS, want)
+	}
+}

--- a/pkg/models/pipeline.go
+++ b/pkg/models/pipeline.go
@@ -95,7 +95,7 @@ func (pe *PipelineEvent) GetMedia() (Media, error) {
 		media.Metadata = &MediaMetadata{}
 		media.Metadata.MotionPixels = 0
 		media.Metadata.FileSize = pe.Payload.FileSize
-		if fps, err := strconv.Atoi(pe.Payload.Metadata.FPS); err == nil {
+		if fps, err := strconv.ParseFloat(pe.Payload.Metadata.FPS, 64); err == nil {
 			media.Metadata.FPS = fps
 		}
 

--- a/pkg/models/pipeline_test.go
+++ b/pkg/models/pipeline_test.go
@@ -331,6 +331,7 @@ func TestPipelineEvent_GetMedia(t *testing.T) {
 						DeviceName: "Front Camera",
 						Duration:   "300",
 						Timestamp:  "1706000000",
+						FPS:        "17.35",
 					},
 				},
 			},
@@ -342,6 +343,7 @@ func TestPipelineEvent_GetMedia(t *testing.T) {
 				StartTimestamp:  1706000000,
 				StorageSolution: "s3",
 				VideoProvider:   "aws",
+				Metadata:        &MediaMetadata{FPS: 17.35},
 			},
 			expectError: false,
 		},
@@ -524,6 +526,9 @@ func TestPipelineEvent_GetMedia(t *testing.T) {
 			}
 			if media.VideoProvider != tt.expectedMedia.VideoProvider {
 				t.Errorf("VideoProvider: got %q, want %q", media.VideoProvider, tt.expectedMedia.VideoProvider)
+			}
+			if media.Metadata != nil && tt.expectedMedia.Metadata != nil && media.Metadata.FPS != tt.expectedMedia.Metadata.FPS {
+				t.Errorf("Metadata.FPS: got %v, want %v", media.Metadata.FPS, tt.expectedMedia.Metadata.FPS)
 			}
 		})
 	}


### PR DESCRIPTION
## Description

This change preserves fractional FPS values throughout the media pipeline instead of truncating them to integers.

Many video sources report non-integer frame rates (for example 17.35, 29.97, or 59.94 FPS). Storing FPS as an `int` caused precision loss during parsing and serialization, which could lead to inaccurate metadata and downstream processing inconsistencies.

The update changes FPS fields from `int` to `float64`, updates pipeline parsing to use `ParseFloat`, and adds coverage for both fractional FPS preservation and backward compatibility with historical integer-based BSON/JSON data.

This improves metadata accuracy while ensuring existing stored records continue to deserialize correctly without migration issues.