### PR TITLE
Return rotated token after organisation switch

### DIFF
--- a/pkg/api/organisation.go
+++ b/pkg/api/organisation.go
@@ -104,6 +104,8 @@ type SetCurrentOrganisationRequest struct {
 }
 type SetCurrentOrganisationResponse struct {
 	Organisation models.Organisation `json:"organisation"`
+	Token        string              `json:"token"`
+	Expire       string              `json:"expire"`
 }
 type SetCurrentOrganisationSuccessResponse struct {
 	SuccessResponse

--- a/src/typescript/types.ts
+++ b/src/typescript/types.ts
@@ -31043,7 +31043,9 @@ export interface components {
             organisationId?: string;
         };
         "api.SetCurrentOrganisationResponse": {
+            expire?: string;
             organisation?: components["schemas"]["models.Organisation"];
+            token?: string;
         };
         "api.SetCurrentOrganisationSuccessResponse": {
             /** @description Application-specific status code */


### PR DESCRIPTION
## Description

Switching organisations changes the security context of the user, but the API response previously did not return the newly rotated authentication token. This made it harder for clients to immediately transition to the updated session state after an organisation switch.

This pull request updates the `SetCurrentOrganisationResponse` to include the rotated token and its expiration timestamp. The generated TypeScript types have also been updated to keep the client contract in sync.

Returning the refreshed token directly from the organisation switch endpoint simplifies client-side authentication handling, reduces the chance of stale-session issues, and ensures consumers can immediately operate with the correct organisation-scoped credentials.