### PR TITLE
feat(marker): link markers to detection tracks

### DIFF
--- a/pkg/models/marker.go
+++ b/pkg/models/marker.go
@@ -37,6 +37,12 @@ type Marker struct {
 	// Additional metadata
 	Metadata *MarkerMetadata `json:"metadata,omitempty" bson:"metadata,omitempty"` // Metadata associated with the marker, such as comments and tags
 
+	// Detections links this marker to the detection track(s) it was derived from,
+	// enabling on-demand bounding-box overlays on the recording. Each entry points
+	// at a stored detection track (see DetectionRef). A marker usually links to a
+	// single track but may reference several; empty when no detection link is known.
+	Detections []DetectionRef `json:"detections,omitempty" bson:"detections,omitempty"`
+
 	// AtRuntimeMetadata contains metadata that is generated at runtime, which can include
 	// more verbose information about the device's current state, capabilities, or configuration.
 	// for example the linked sites details, etc.
@@ -93,6 +99,18 @@ type MarkerBox struct {
 	Y      float64 `json:"y" bson:"y" example:"0.34"`           // Top edge, fraction of frame height
 	Width  float64 `json:"width" bson:"width" example:"0.20"`   // Box width, fraction of frame width
 	Height float64 `json:"height" bson:"height" example:"0.10"` // Box height, fraction of frame height
+}
+
+// DetectionRef links a marker to a specific detection track it was derived from,
+// so the UI can toggle that detection's bounding-box overlay on the recording on
+// demand. It points into the dedicated "detections" collection: RunId is the
+// DetectionRun's Source.RunId and TrackId is the FaceRedactionTrack.Id within
+// that run. Both resolve against the same recording the marker attaches to (see
+// Marker.MediaKeys / DetectionRun.Key), so no organisation/device scoping is
+// duplicated here.
+type DetectionRef struct {
+	RunId   string `json:"runId" bson:"runId" example:"01J8Z9Q2A7K3"` // DetectionRun.Source.RunId
+	TrackId string `json:"trackId" bson:"trackId" example:"track-3"` // FaceRedactionTrack.Id within the run
 }
 
 type MarkerAtRuntimeMetadata struct {

--- a/pkg/models/media.go
+++ b/pkg/models/media.go
@@ -76,6 +76,11 @@ type MarkerSummary struct {
 	TagNames       []string `json:"tagNames,omitempty" bson:"tagNames,omitempty"`
 	StartTimestamp int64    `json:"startTimestamp,omitempty" bson:"startTimestamp,omitempty"`
 	EndTimestamp   int64    `json:"endTimestamp,omitempty" bson:"endTimestamp,omitempty"`
+
+	// Detections mirrors the source marker's Detections so the frontend can map a
+	// summarised marker to its detection track(s) — and toggle their bounding-box
+	// overlay — without a second query. Empty when the marker has no detection link.
+	Detections []DetectionRef `json:"detections,omitempty" bson:"detections,omitempty"`
 }
 
 // We can store additional metadata for media files, such as tags and classifications.

--- a/pkg/properties/media.go
+++ b/pkg/properties/media.go
@@ -37,6 +37,7 @@ const (
 	MarkerSummaryTagNames = "tagNames"
 	MarkerSummaryStartTimestamp = "startTimestamp"
 	MarkerSummaryEndTimestamp = "endTimestamp"
+	MarkerSummaryDetections = "detections"
 )
 
 // Media property field names (BSON)


### PR DESCRIPTION
## Description

This change introduces explicit links between markers and their originating detection tracks.

By adding `DetectionRef` support to both `Marker` and `MarkerSummary`, the frontend can directly associate markers with stored detection tracks and enable bounding-box overlays on recordings without requiring additional lookup queries. This improves the playback and review experience while keeping the relationship between detections and derived markers consistent and traceable.

The update also propagates detection references into marker summaries, ensuring lightweight media responses still contain enough context for overlay rendering and interaction. This reduces API round-trips and simplifies frontend integration.

Overall, this improves the project by making detection-derived markers more actionable, improving UI responsiveness, and establishing a clearer data model for linking annotations back to their detection sources.