### PR TITLE
feat(workflow): persist canonical organisationId tenant key

### DIFF
--- a/pkg/models/workflow.go
+++ b/pkg/models/workflow.go
@@ -351,7 +351,13 @@ type Workflow struct {
 	Stages         []WorkflowStage `json:"stages,omitempty" bson:"stages,omitempty"`
 	UserId         string          `json:"user_id" bson:"user_id,omitempty"`
 	Username       string          `json:"username" bson:"username,omitempty"`
-	OrganisationId string          `json:"organisation_id" bson:"organisation_id,omitempty"`
+	// OrganisationId is the canonical tenant key. It is persisted as the
+	// camelCase `organisationId` field to match the platform-wide convention for
+	// organisation-owned domain resources; the JSON tag stays `organisation_id`
+	// for API back-compatibility. Documents written before this spelling change
+	// carry the legacy snake-case `organisation_id` field and are matched by the
+	// reader's legacy fallback until a Phase 4 backfill rewrites them.
+	OrganisationId string          `json:"organisation_id" bson:"organisationId,omitempty"`
 	CreatedAt      int64           `json:"created_at" bson:"created_at,omitempty"`
 	UpdatedAt      int64           `json:"updated_at" bson:"updated_at,omitempty"`
 }

--- a/pkg/models/workflow.go
+++ b/pkg/models/workflow.go
@@ -2,8 +2,10 @@ package models
 
 import (
 	"crypto/sha256"
+	"encoding/json"
 	"time"
 
+	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
@@ -301,9 +303,9 @@ const (
 	// scoped to that user's organisation. It is the default (an empty Source is
 	// treated as this) and is editable in the UI.
 	WorkflowSourceUser WorkflowSource = "user"
-	// WorkflowSourceConfig is a workflow seeded from deployment configuration
+	// WorkflowSourceConfig is a workflow loaded from deployment configuration
 	// (helm). It is deployment-global — available to every organisation — and
-	// ops-managed: created and updated only by the seeding reconcile, and
+	// ops-managed: created and updated only through deployment configuration, and
 	// read-only in the UI. A config workflow carries an empty OrganisationId to
 	// signal its global scope (see IsGlobal).
 	WorkflowSourceConfig WorkflowSource = "config"
@@ -320,7 +322,7 @@ type Workflow struct {
 	Enabled     bool               `json:"enabled" bson:"enabled"`
 	// Source is the workflow's provenance and availability (see WorkflowSource).
 	// Empty means WorkflowSourceUser: an ordinary user workflow scoped to its
-	// OrganisationId. WorkflowSourceConfig marks a helm-seeded, deployment-global,
+	// OrganisationId. WorkflowSourceConfig marks a Helm-defined, deployment-global,
 	// read-only workflow. Every workflow persisted before this field existed
 	// decodes as user.
 	Source WorkflowSource `json:"source,omitempty" bson:"source,omitempty"`
@@ -348,18 +350,87 @@ type Workflow struct {
 	// meaningful here; a stage's deployment fields (image, queue, replicas, …) are
 	// resolved by Operation against the shared deployed catalog, not per workflow.
 	// Operations need only be unique within a single workflow, not globally.
-	Stages         []WorkflowStage `json:"stages,omitempty" bson:"stages,omitempty"`
-	UserId         string          `json:"user_id" bson:"user_id,omitempty"`
-	Username       string          `json:"username" bson:"username,omitempty"`
+	Stages   []WorkflowStage `json:"stages,omitempty" bson:"stages,omitempty"`
+	UserId   string          `json:"userId" bson:"userId,omitempty"`
+	Username string          `json:"username" bson:"username,omitempty"`
 	// OrganisationId is the canonical tenant key. It is persisted as the
 	// camelCase `organisationId` field to match the platform-wide convention for
-	// organisation-owned domain resources; the JSON tag stays `organisation_id`
-	// for API back-compatibility. Documents written before this spelling change
-	// carry the legacy snake-case `organisation_id` field and are matched by the
-	// reader's legacy fallback until a Phase 4 backfill rewrites them.
-	OrganisationId string          `json:"organisation_id" bson:"organisationId,omitempty"`
-	CreatedAt      int64           `json:"created_at" bson:"created_at,omitempty"`
-	UpdatedAt      int64           `json:"updated_at" bson:"updated_at,omitempty"`
+	// organisation-owned domain resources. Database-backed workflows are not yet
+	// materially used in deployments, so new documents start with this canonical
+	// contract while readers may retain a legacy `organisation_id` fallback.
+	OrganisationId string `json:"organisationId" bson:"organisationId,omitempty"`
+	CreatedAt      int64  `json:"createdAt" bson:"createdAt,omitempty"`
+	UpdatedAt      int64  `json:"updatedAt" bson:"updatedAt,omitempty"`
+	// Audit carries bounded actor/timestamp metadata for database-backed user
+	// workflows. It is omitted from Helm-defined global workflows unless set.
+	Audit *Audit `json:"audit,omitempty" bson:"audit,omitempty"`
+}
+
+// UnmarshalJSON accepts the pre-canonical snake_case ownership and timestamp
+// fields during the migration window. Marshal output remains canonical because
+// the Workflow field tags above are camelCase. A populated canonical field wins
+// when both representations are present.
+func (w *Workflow) UnmarshalJSON(data []byte) error {
+	type workflowAlias Workflow
+	decoded := struct {
+		*workflowAlias
+		LegacyUserId         string `json:"user_id"`
+		LegacyOrganisationId string `json:"organisation_id"`
+		LegacyCreatedAt      int64  `json:"created_at"`
+		LegacyUpdatedAt      int64  `json:"updated_at"`
+	}{workflowAlias: (*workflowAlias)(w)}
+
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	w.populateLegacyFields(
+		decoded.LegacyUserId,
+		decoded.LegacyOrganisationId,
+		decoded.LegacyCreatedAt,
+		decoded.LegacyUpdatedAt,
+	)
+	return nil
+}
+
+// UnmarshalBSON provides the same transitional compatibility for existing
+// workflow documents. New and updated documents are always written using the
+// canonical camelCase BSON tags on Workflow.
+func (w *Workflow) UnmarshalBSON(data []byte) error {
+	type workflowAlias Workflow
+	var decoded struct {
+		Workflow             workflowAlias `bson:",inline"`
+		LegacyUserId         string        `bson:"user_id"`
+		LegacyOrganisationId string        `bson:"organisation_id"`
+		LegacyCreatedAt      int64         `bson:"created_at"`
+		LegacyUpdatedAt      int64         `bson:"updated_at"`
+	}
+
+	if err := bson.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	*w = Workflow(decoded.Workflow)
+	w.populateLegacyFields(
+		decoded.LegacyUserId,
+		decoded.LegacyOrganisationId,
+		decoded.LegacyCreatedAt,
+		decoded.LegacyUpdatedAt,
+	)
+	return nil
+}
+
+func (w *Workflow) populateLegacyFields(userId, organisationId string, createdAt, updatedAt int64) {
+	if w.UserId == "" {
+		w.UserId = userId
+	}
+	if w.OrganisationId == "" {
+		w.OrganisationId = organisationId
+	}
+	if w.CreatedAt == 0 {
+		w.CreatedAt = createdAt
+	}
+	if w.UpdatedAt == 0 {
+		w.UpdatedAt = updatedAt
+	}
 }
 
 // EffectiveSource returns the workflow's provenance, defaulting an empty Source
@@ -373,7 +444,7 @@ func (w *Workflow) EffectiveSource() WorkflowSource {
 }
 
 // IsGlobal reports whether this workflow is available to every organisation. A
-// global workflow is one seeded from deployment configuration
+// global workflow is one loaded from deployment configuration
 // (WorkflowSourceConfig) with no owning organisation, so surfaces list it
 // alongside the caller's own workflows without any per-org copy.
 func (w *Workflow) IsGlobal() bool {
@@ -383,7 +454,7 @@ func (w *Workflow) IsGlobal() bool {
 // EffectiveID resolves the stable, run-facing id of a workflow and is the single
 // source of truth for that derivation. A workflow with an explicit Id (a
 // persisted user workflow, or a config workflow that carries one) uses it; a
-// config workflow seeded from helm without an id gets a deterministic id derived
+// config workflow loaded from Helm without an id gets a deterministic id derived
 // from its Name, so the same definition always yields the same id across
 // restarts and every service agrees on its identity without persisting it — a
 // run one service seeds resolves to the workflow another service loaded from the
@@ -505,7 +576,7 @@ type GetWorkflowsOutput struct {
 
 type GetWorkflowInput struct {
 	User       User   `json:"user"`
-	WorkflowId string `json:"workflow_id"`
+	WorkflowId string `json:"workflowId"`
 }
 
 type GetWorkflowOutput struct {
@@ -523,7 +594,7 @@ type CreateWorkflowOutput struct {
 
 type UpdateWorkflowInput struct {
 	User       User     `json:"user"`
-	WorkflowId string   `json:"workflow_id"`
+	WorkflowId string   `json:"workflowId"`
 	Workflow   Workflow `json:"workflow"`
 }
 
@@ -533,7 +604,7 @@ type UpdateWorkflowOutput struct {
 
 type DeleteWorkflowInput struct {
 	User       User   `json:"user"`
-	WorkflowId string `json:"workflow_id"`
+	WorkflowId string `json:"workflowId"`
 }
 
 type DeleteWorkflowOutput struct{}

--- a/pkg/models/workflow_test.go
+++ b/pkg/models/workflow_test.go
@@ -10,6 +10,188 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
+func TestWorkflowSerializationUsesCanonicalFieldNames(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	workflow := Workflow{
+		UserId:         "user-1",
+		OrganisationId: "org-1",
+		CreatedAt:      1,
+		UpdatedAt:      2,
+		Audit: &Audit{
+			CreatedBy: "user-1",
+			CreatedAt: now,
+			UpdatedBy: "user-1",
+			UpdatedAt: now,
+		},
+	}
+
+	jsonData, err := json.Marshal(workflow)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var jsonDocument map[string]any
+	if err := json.Unmarshal(jsonData, &jsonDocument); err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{"userId", "organisationId", "createdAt", "updatedAt", "audit"} {
+		if _, exists := jsonDocument[key]; !exists {
+			t.Errorf("canonical JSON field %q was not emitted", key)
+		}
+	}
+	for _, key := range []string{"user_id", "organisation_id", "created_at", "updated_at"} {
+		if _, exists := jsonDocument[key]; exists {
+			t.Errorf("legacy JSON field %q was emitted", key)
+		}
+	}
+
+	bsonData, err := bson.Marshal(workflow)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var bsonDocument bson.M
+	if err := bson.Unmarshal(bsonData, &bsonDocument); err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{"userId", "organisationId", "createdAt", "updatedAt", "audit"} {
+		if _, exists := bsonDocument[key]; !exists {
+			t.Errorf("canonical BSON field %q was not emitted", key)
+		}
+	}
+	for _, key := range []string{"user_id", "organisation_id", "created_at", "updated_at"} {
+		if _, exists := bsonDocument[key]; exists {
+			t.Errorf("legacy BSON field %q was emitted", key)
+		}
+	}
+}
+
+func TestWorkflowDeserializationAcceptsLegacyFieldNames(t *testing.T) {
+	tests := []struct {
+		name     string
+		decode   func(*Workflow) error
+		workflow Workflow
+	}{
+		{
+			name: "JSON",
+			decode: func(workflow *Workflow) error {
+				return json.Unmarshal([]byte(`{
+					"user_id":"legacy-user",
+					"organisation_id":"legacy-org",
+					"created_at":1,
+					"updated_at":2
+				}`), workflow)
+			},
+		},
+		{
+			name: "BSON",
+			decode: func(workflow *Workflow) error {
+				data, err := bson.Marshal(bson.M{
+					"user_id":         "legacy-user",
+					"organisation_id": "legacy-org",
+					"created_at":      int64(1),
+					"updated_at":      int64(2),
+				})
+				if err != nil {
+					return err
+				}
+				return bson.Unmarshal(data, workflow)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var workflow Workflow
+			if err := tc.decode(&workflow); err != nil {
+				t.Fatal(err)
+			}
+			if workflow.UserId != "legacy-user" || workflow.OrganisationId != "legacy-org" || workflow.CreatedAt != 1 || workflow.UpdatedAt != 2 {
+				t.Fatalf("legacy fields were not decoded: %+v", workflow)
+			}
+		})
+	}
+}
+
+func TestWorkflowDeserializationPrefersCanonicalFieldNames(t *testing.T) {
+	tests := []struct {
+		name   string
+		decode func(*Workflow) error
+	}{
+		{
+			name: "JSON",
+			decode: func(workflow *Workflow) error {
+				return json.Unmarshal([]byte(`{
+					"userId":"canonical-user","user_id":"legacy-user",
+					"organisationId":"canonical-org","organisation_id":"legacy-org",
+					"createdAt":10,"created_at":1,
+					"updatedAt":20,"updated_at":2
+				}`), workflow)
+			},
+		},
+		{
+			name: "BSON",
+			decode: func(workflow *Workflow) error {
+				data, err := bson.Marshal(bson.M{
+					"userId":          "canonical-user",
+					"user_id":         "legacy-user",
+					"organisationId":  "canonical-org",
+					"organisation_id": "legacy-org",
+					"createdAt":       int64(10),
+					"created_at":      int64(1),
+					"updatedAt":       int64(20),
+					"updated_at":      int64(2),
+				})
+				if err != nil {
+					return err
+				}
+				return bson.Unmarshal(data, workflow)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var workflow Workflow
+			if err := tc.decode(&workflow); err != nil {
+				t.Fatal(err)
+			}
+			if workflow.UserId != "canonical-user" || workflow.OrganisationId != "canonical-org" || workflow.CreatedAt != 10 || workflow.UpdatedAt != 20 {
+				t.Fatalf("canonical fields did not take precedence: %+v", workflow)
+			}
+		})
+	}
+}
+
+func TestWorkflowRepositoryInputSerializationUsesCamelCaseIds(t *testing.T) {
+	tests := []struct {
+		name string
+		in   any
+		key  string
+	}{
+		{name: "get workflow", in: GetWorkflowInput{WorkflowId: "workflow-1"}, key: "workflowId"},
+		{name: "update workflow", in: UpdateWorkflowInput{WorkflowId: "workflow-1"}, key: "workflowId"},
+		{name: "delete workflow", in: DeleteWorkflowInput{WorkflowId: "workflow-1"}, key: "workflowId"},
+		{name: "get workflow stage", in: GetWorkflowStageInput{StageId: "stage-1"}, key: "stageId"},
+		{name: "update workflow stage", in: UpdateWorkflowStageInput{StageId: "stage-1"}, key: "stageId"},
+		{name: "delete workflow stage", in: DeleteWorkflowStageInput{StageId: "stage-1"}, key: "stageId"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			data, err := json.Marshal(tc.in)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var document map[string]any
+			if err := json.Unmarshal(data, &document); err != nil {
+				t.Fatal(err)
+			}
+			if _, exists := document[tc.key]; !exists {
+				t.Fatalf("canonical JSON field %q was not emitted", tc.key)
+			}
+		})
+	}
+}
+
 func TestWorkflowTrigger_EffectiveType(t *testing.T) {
 	if got := (WorkflowTrigger{}).EffectiveType(); got != WorkflowTriggerAutomatic {
 		t.Fatalf("empty Type should default to automatic, got %q", got)

--- a/pkg/models/workflowstage.go
+++ b/pkg/models/workflowstage.go
@@ -307,7 +307,7 @@ type GetWorkflowStagesOutput struct {
 
 type GetWorkflowStageInput struct {
 	User    User   `json:"user"`
-	StageId string `json:"stage_id"`
+	StageId string `json:"stageId"`
 }
 
 type GetWorkflowStageOutput struct {
@@ -325,7 +325,7 @@ type CreateWorkflowStageOutput struct {
 
 type UpdateWorkflowStageInput struct {
 	User    User          `json:"user"`
-	StageId string        `json:"stage_id"`
+	StageId string        `json:"stageId"`
 	Stage   WorkflowStage `json:"stage"`
 }
 
@@ -335,7 +335,7 @@ type UpdateWorkflowStageOutput struct {
 
 type DeleteWorkflowStageInput struct {
 	User    User   `json:"user"`
-	StageId string `json:"stage_id"`
+	StageId string `json:"stageId"`
 }
 
 type DeleteWorkflowStageOutput struct{}

--- a/pkg/properties/marker.go
+++ b/pkg/properties/marker.go
@@ -3,6 +3,12 @@
 
 package properties
 
+// DetectionRef property field names (BSON)
+const (
+	DetectionRefRunId = "runId"
+	DetectionRefTrackId = "trackId"
+)
+
 // Marker property field names (BSON)
 const (
 	MarkerId = "_id"
@@ -20,6 +26,7 @@ const (
 	MarkerDescription = "description"
 	MarkerCategories = "categories"
 	MarkerMetadata = "metadata"
+	MarkerDetections = "detections"
 	MarkerAtRuntimeMetadata = "atRuntimeMetadata"
 	MarkerSynchronize = "synchronize"
 	MarkerAudit = "audit"

--- a/pkg/properties/workflow.go
+++ b/pkg/properties/workflow.go
@@ -15,11 +15,12 @@ const (
 	WorkflowNodes = "nodes"
 	WorkflowEdges = "edges"
 	WorkflowStages = "stages"
-	WorkflowUserId = "user_id"
+	WorkflowUserId = "userId"
 	WorkflowUsername = "username"
 	WorkflowOrganisationId = "organisationId"
-	WorkflowCreatedAt = "created_at"
-	WorkflowUpdatedAt = "updated_at"
+	WorkflowCreatedAt = "createdAt"
+	WorkflowUpdatedAt = "updatedAt"
+	WorkflowAudit = "audit"
 )
 
 // WorkflowEdge property field names (BSON)

--- a/pkg/properties/workflow.go
+++ b/pkg/properties/workflow.go
@@ -17,7 +17,7 @@ const (
 	WorkflowStages = "stages"
 	WorkflowUserId = "user_id"
 	WorkflowUsername = "username"
-	WorkflowOrganisationId = "organisation_id"
+	WorkflowOrganisationId = "organisationId"
 	WorkflowCreatedAt = "created_at"
 	WorkflowUpdatedAt = "updated_at"
 )

--- a/src/typescript/types.ts
+++ b/src/typescript/types.ts
@@ -6244,6 +6244,45 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/internal/detectionref": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get DetectionRef (schema generation only)
+         * @description Internal endpoint used only to ensure DetectionRef schema is generated in OpenAPI spec
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["models.DetectionRef"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/internal/detectionrejection": {
         parameters: {
             query?: never;
@@ -32604,11 +32643,11 @@ export interface components {
         "models.DeleteVideowallOutput": Record<string, never>;
         "models.DeleteWorkflowInput": {
             user?: components["schemas"]["models.User"];
-            workflow_id?: string;
+            workflowId?: string;
         };
         "models.DeleteWorkflowOutput": Record<string, never>;
         "models.DeleteWorkflowStageInput": {
-            stage_id?: string;
+            stageId?: string;
             user?: components["schemas"]["models.User"];
         };
         "models.DeleteWorkflowStageOutput": Record<string, never>;
@@ -32677,6 +32716,18 @@ export interface components {
             height?: number;
             rotation?: number;
             width?: number;
+        };
+        "models.DetectionRef": {
+            /**
+             * @description DetectionRun.Source.RunId
+             * @example 01J8Z9Q2A7K3
+             */
+            runId?: string;
+            /**
+             * @description FaceRedactionTrack.Id within the run
+             * @example track-3
+             */
+            trackId?: string;
         };
         "models.DetectionRun": {
             categories?: components["schemas"]["models.DetectionCategory"][];
@@ -33123,13 +33174,13 @@ export interface components {
         };
         "models.GetWorkflowInput": {
             user?: components["schemas"]["models.User"];
-            workflow_id?: string;
+            workflowId?: string;
         };
         "models.GetWorkflowOutput": {
             workflow?: components["schemas"]["models.Workflow"];
         };
         "models.GetWorkflowStageInput": {
-            stage_id?: string;
+            stageId?: string;
             user?: components["schemas"]["models.User"];
         };
         "models.GetWorkflowStageOutput": {
@@ -33337,6 +33388,11 @@ export interface components {
              * @example Person forcably opened a door
              */
             description?: string;
+            /** @description Detections links this marker to the detection track(s) it was derived from,
+             *     enabling on-demand bounding-box overlays on the recording. Each entry points
+             *     at a stored detection track (see DetectionRef). A marker usually links to a
+             *     single track but may reference several; empty when no detection link is known. */
+            detections?: components["schemas"]["models.DetectionRef"][];
             /**
              * @description RBAC information
              * @example 686a906345c1df594939f9j25f4
@@ -33605,6 +33661,10 @@ export interface components {
         };
         "models.MarkerSummary": {
             categoryNames?: string[];
+            /** @description Detections mirrors the source marker's Detections so the frontend can map a
+             *     summarised marker to its detection track(s) — and toggle their bounding-box
+             *     overlay — without a second query. Empty when the marker has no detection link. */
+            detections?: components["schemas"]["models.DetectionRef"][];
             endTimestamp?: number;
             eventNames?: string[];
             name?: string;
@@ -34830,14 +34890,14 @@ export interface components {
         "models.UpdateWorkflowInput": {
             user?: components["schemas"]["models.User"];
             workflow?: components["schemas"]["models.Workflow"];
-            workflow_id?: string;
+            workflowId?: string;
         };
         "models.UpdateWorkflowOutput": {
             workflow?: components["schemas"]["models.Workflow"];
         };
         "models.UpdateWorkflowStageInput": {
             stage?: components["schemas"]["models.WorkflowStage"];
-            stage_id?: string;
+            stageId?: string;
             user?: components["schemas"]["models.User"];
         };
         "models.UpdateWorkflowStageOutput": {
@@ -35119,17 +35179,25 @@ export interface components {
             timezone?: string;
         };
         "models.Workflow": {
-            created_at?: number;
+            /** @description Audit carries bounded actor/timestamp metadata for database-backed user
+             *     workflows. It is omitted from Helm-defined global workflows unless set. */
+            audit?: components["schemas"]["models.Audit"];
+            createdAt?: number;
             description?: string;
             edges?: components["schemas"]["models.WorkflowEdge"][];
             enabled?: boolean;
             id?: string;
             name?: string;
             nodes?: components["schemas"]["models.WorkflowNode"][];
-            organisation_id?: string;
+            /** @description OrganisationId is the canonical tenant key. It is persisted as the
+             *     camelCase `organisationId` field to match the platform-wide convention for
+             *     organisation-owned domain resources. Database-backed workflows are not yet
+             *     materially used in deployments, so new documents start with this canonical
+             *     contract while readers may retain a legacy `organisation_id` fallback. */
+            organisationId?: string;
             /** @description Source is the workflow's provenance and availability (see WorkflowSource).
              *     Empty means WorkflowSourceUser: an ordinary user workflow scoped to its
-             *     OrganisationId. WorkflowSourceConfig marks a helm-seeded, deployment-global,
+             *     OrganisationId. WorkflowSourceConfig marks a Helm-defined, deployment-global,
              *     read-only workflow. Every workflow persisted before this field existed
              *     decodes as user. */
             source?: components["schemas"]["models.WorkflowSource"];
@@ -35156,8 +35224,8 @@ export interface components {
              *     carry both an automatic and a manual trigger so it runs on its own for
              *     matching recordings and can also be launched on demand from a surface. */
             triggers?: components["schemas"]["models.WorkflowTrigger"][];
-            updated_at?: number;
-            user_id?: string;
+            updatedAt?: number;
+            userId?: string;
             username?: string;
         };
         "models.WorkflowDevice": {
@@ -35572,6 +35640,7 @@ export namespace models {
     export type DeprecatedPreset = components['schemas']['models.DeprecatedPreset'];
     export type DetectionCategory = components['schemas']['models.DetectionCategory'];
     export type DetectionMedia = components['schemas']['models.DetectionMedia'];
+    export type DetectionRef = components['schemas']['models.DetectionRef'];
     export type DetectionRun = components['schemas']['models.DetectionRun'];
     export type DetectionSource = components['schemas']['models.DetectionSource'];
     export type Detections = components['schemas']['models.Detections'];


### PR DESCRIPTION
## Description

This change standardises workflow persistence and API contracts around canonical camelCase tenant and ownership fields, with `organisationId` becoming the authoritative tenant key across workflow models, BSON storage, JSON APIs, and generated TypeScript types.

The main motivation is consistency. Workflows were still using legacy snake_case field names (`organisation_id`, `user_id`, etc.) while the rest of the platform had already converged on camelCase resource identifiers. That mismatch increased integration friction, complicated schema evolution, and created ambiguity around the canonical tenant identifier used by downstream services and clients.

To avoid breaking existing persisted workflow documents, this PR introduces transitional compatibility during deserialisation. Existing snake_case JSON and BSON payloads continue to load correctly, while all newly written data is emitted using the canonical camelCase contract. Canonical fields also take precedence when both formats are present, ensuring deterministic behaviour during migration.

This improves the project by:
- Aligning workflow storage and APIs with platform-wide naming conventions.
- Establishing a single canonical tenant ownership key (`organisationId`) for future development.
- Preserving backwards compatibility with existing persisted workflow documents and clients.
- Reducing migration risk by supporting mixed-format reads while enforcing canonical writes.
- Expanding automated test coverage around serialisation compatibility and field precedence guarantees.

The PR also updates related workflow/stage request payloads to use camelCase identifiers (`workflowId`, `stageId`), adds audit metadata support for workflows, and refreshes generated API schemas/types so frontend and backend contracts remain consistent.