### PR TITLE
docs(workflows): align run contract documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ type User struct {
     ID        string `json:"id" bson:"_id,omitempty"`
     Email     string `json:"email" bson:"email" validate:"required,email"`
     Name      string `json:"name" bson:"name" validate:"required"`
-    CreatedAt int64  `json:"createdAt" bson:"created_at"`
+    CreatedAt int64  `json:"createdAt" bson:"createdAt"`
 }
 ```
 

--- a/pkg/models/workflowrun.go
+++ b/pkg/models/workflowrun.go
@@ -114,8 +114,9 @@ type WorkflowRun struct {
 	Operation string `json:"operation,omitempty" bson:"-"`
 
 	// RunId is the run's identifier on the wire (the hex of the document Id). It
-	// is empty on the analysis hand-off — the run is keyed by Key until the
-	// engine opens it — and set on every engine→worker dispatch. The persisted
+	// is empty on an untargeted analysis hand-off; after workflow matching, the
+	// engine derives a distinct document identity per recording, organisation,
+	// and workflow. It is set on every engine→worker dispatch. The persisted
 	// identity is Id, so RunId itself is wire-only.
 	//
 	// It is never set by hand: MarshalJSON derives it from Id whenever a run that
@@ -132,10 +133,9 @@ type WorkflowRun struct {
 	Id primitive.ObjectID `json:"-" bson:"_id,omitempty"`
 
 	// WorkflowId is the id of the Workflow definition (models.Workflow) this run
-	// executes — the authored graph (nodes/edges/trigger) the run is an execution
-	// of, as opposed to the global stage registry. Forward-looking: it is set once
-	// the engine executes Workflow graphs; while the engine is driven by the flat
-	// stage registry it is empty.
+	// executes — the authored graph (nodes/edges/triggers) the run is an execution
+	// of. It is empty only on an untargeted analysis hand-off; the engine stamps it
+	// as it fans that recording out to each matching config or database workflow.
 	WorkflowId string `json:"workflowId,omitempty" bson:"workflowid,omitempty"`
 
 	// WorkflowName is the human-readable name of that Workflow, carried so a
@@ -172,8 +172,10 @@ type WorkflowRun struct {
 	// (a case id today; a temporal device-series id is a forward-looking twin).
 	SourceRef string `json:"sourceRef,omitempty" bson:"sourceref,omitempty"`
 
-	// Key is the media key the run is about: its natural identity, used to load
-	// or open the run document. Copied from the recording at hand-off time.
+	// Key is the media key the run is about. It is copied from the recording at
+	// hand-off time and can group all runs for that recording, but is not unique:
+	// run state is correlated by Id/RunId because several workflows and manual
+	// re-runs may execute over the same key.
 	Key string `json:"key,omitempty" bson:"key"`
 
 	// RecordingTimestamp is the recording's start time (unix seconds), copied

--- a/src/typescript/types.ts
+++ b/src/typescript/types.ts
@@ -35290,8 +35290,10 @@ export interface components {
             inputs?: {
                 [key: string]: unknown;
             };
-            /** @description Key is the media key the run is about: its natural identity, used to load
-             *     or open the run document. Copied from the recording at hand-off time. */
+            /** @description Key is the media key the run is about. It is copied from the recording at
+             *     hand-off time and can group all runs for that recording, but is not unique:
+             *     run state is correlated by Id/RunId because several workflows and manual
+             *     re-runs may execute over the same key. */
             key?: string;
             /** @description Operation marks the message's role on the workflows queue (wire-only):
              *       - "event": a fresh run hand-off from analysis. It opens the run and
@@ -35357,8 +35359,9 @@ export interface components {
                 [key: string]: unknown;
             };
             /** @description RunId is the run's identifier on the wire (the hex of the document Id). It
-             *     is empty on the analysis hand-off — the run is keyed by Key until the
-             *     engine opens it — and set on every engine→worker dispatch. The persisted
+             *     is empty on an untargeted analysis hand-off; after workflow matching, the
+             *     engine derives a distinct document identity per recording, organisation,
+             *     and workflow. It is set on every engine→worker dispatch. The persisted
              *     identity is Id, so RunId itself is wire-only.
              *
              *     It is never set by hand: MarshalJSON derives it from Id whenever a run that
@@ -35412,10 +35415,9 @@ export interface components {
              *     is OrganisationId. */
             user?: components["schemas"]["models.WorkflowUser"];
             /** @description WorkflowId is the id of the Workflow definition (models.Workflow) this run
-             *     executes — the authored graph (nodes/edges/trigger) the run is an execution
-             *     of, as opposed to the global stage registry. Forward-looking: it is set once
-             *     the engine executes Workflow graphs; while the engine is driven by the flat
-             *     stage registry it is empty. */
+             *     executes — the authored graph (nodes/edges/triggers) the run is an execution
+             *     of. It is empty only on an untargeted analysis hand-off; the engine stamps it
+             *     as it fans that recording out to each matching config or database workflow. */
             workflowId?: string;
             /** @description WorkflowName is the human-readable name of that Workflow, carried so a
              *     dispatch/result is legible in worker context and logs without a lookup.


### PR DESCRIPTION
## Description

This PR aligns workflow run documentation across the Go models, generated TypeScript types, and README examples so the run contract reflects current engine behaviour.

The updated documentation clarifies:
- how `RunId` is derived and when it becomes available,
- how `WorkflowId` is assigned during workflow matching,
- why `Key` is not a unique run identifier and cannot be used alone for run correlation,
- and the intended persisted vs wire-only identities in the workflow pipeline.

This improves the project by reducing ambiguity around workflow execution semantics and preventing incorrect assumptions by consumers integrating with the API or queue payloads. Keeping the generated TypeScript types and README in sync with the backend model also helps avoid drift between implementation and client expectations.

Additionally, the README BSON tag example was corrected to match the actual field naming convention (`createdAt`).