### PR TITLE
feat(models): add optional projectId sub-scope to tenant-scoped models

### DIFF
--- a/pkg/api/project.go
+++ b/pkg/api/project.go
@@ -1,0 +1,102 @@
+package api
+
+import "github.com/uug-ai/models/pkg/models"
+
+// ProjectStatus represents specific status codes for project operations.
+type ProjectStatus string
+
+const (
+	ProjectBindingFailed ProjectStatus = "project_binding_failed"
+	ProjectMissingInfo   ProjectStatus = "project_missing_info"
+	ProjectFound         ProjectStatus = "project_found"
+	ProjectNotFound      ProjectStatus = "project_not_found"
+	ProjectGetAllSuccess ProjectStatus = "project_get_all_success"
+	ProjectGetAllFailed  ProjectStatus = "project_get_all_failed"
+	ProjectUpdateSuccess ProjectStatus = "project_update_success"
+	ProjectUpdateFailed  ProjectStatus = "project_update_failed"
+)
+
+// String returns the string representation of the project status.
+func (s ProjectStatus) String() string {
+	return string(s)
+}
+
+// Translate returns the translated string representation of the project status
+// in the specified language.
+func (s ProjectStatus) Translate(lang string) string {
+	translations := map[string]map[ProjectStatus]string{
+		"en": {
+			ProjectBindingFailed: "Project binding failed",
+			ProjectMissingInfo:   "Project is missing required information",
+			ProjectFound:         "Project found",
+			ProjectNotFound:      "Project not found",
+			ProjectGetAllSuccess: "Projects retrieved successfully",
+			ProjectGetAllFailed:  "Failed to retrieve projects",
+			ProjectUpdateSuccess: "Project updated successfully",
+			ProjectUpdateFailed:  "Failed to update project",
+		},
+	}
+
+	if langTranslations, exists := translations[lang]; exists {
+		if translation, exists := langTranslations[s]; exists {
+			return translation
+		}
+	}
+
+	if enTranslations, exists := translations["en"]; exists {
+		if translation, exists := enTranslations[s]; exists {
+			return translation
+		}
+	}
+
+	return s.String()
+}
+
+// ---------- Request / Response DTOs (project domain) ----------
+//
+// These are the typed request bodies and response envelopes for the versioned
+// project selection endpoints, mirroring the organisation domain. A project is
+// an optional sub-scope within an organisation; a nil active project means the
+// caller is scoped organisation-wide.
+
+// GetProjects lists the projects in the caller's active organisation.
+// @Router /projects [get]
+type GetProjectsResponse struct {
+	Projects []models.Project `json:"projects"`
+}
+type GetProjectsSuccessResponse struct {
+	SuccessResponse
+	Data GetProjectsResponse `json:"data"`
+}
+type GetProjectsErrorResponse struct {
+	ErrorResponse
+}
+
+// GetProject resolves a single project, currently the caller's active one
+// (/projects/current).
+type GetProjectResponse struct {
+	Project models.Project `json:"project"`
+}
+type GetProjectSuccessResponse struct {
+	SuccessResponse
+	Data GetProjectResponse `json:"data"`
+}
+type GetProjectErrorResponse struct {
+	ErrorResponse
+}
+
+// SetCurrentProject selects the active project sub-scope for the caller.
+// @Router /projects/current [patch]
+type SetCurrentProjectRequest struct {
+	ProjectId string `json:"projectId"`
+}
+type SetCurrentProjectResponse struct {
+	Project models.Project `json:"project"`
+}
+type SetCurrentProjectSuccessResponse struct {
+	SuccessResponse
+	Data SetCurrentProjectResponse `json:"data"`
+}
+type SetCurrentProjectErrorResponse struct {
+	ErrorResponse
+}

--- a/pkg/models/alert.go
+++ b/pkg/models/alert.go
@@ -49,6 +49,10 @@ type CustomAlert struct {
 	DateRangeSchedule   []*DateRangeSchedule `json:"dateRangeSchedule" bson:"dateRangeSchedule"`
 	OrganisationId      string               `json:"organisationId" bson:"organisationId"`
 
+	// ProjectId optionally places the alert in a project within its organisation.
+	// A nil value keeps the alert organisation-wide.
+	ProjectId *primitive.ObjectID `json:"projectId,omitempty" bson:"projectId,omitempty"`
+
 	// Deprecated: legacy time range fields. Use WeeklySchedule/DateRangeSchedule instead.
 	TimeRange1Max int32 `json:"timeRange1Max" bson:"timeRange1Max"`
 	TimeRange1Min int32 `json:"timeRange1Min" bson:"timeRange1Min"`

--- a/pkg/models/analysis.go
+++ b/pkg/models/analysis.go
@@ -3,22 +3,27 @@ package models
 import "go.mongodb.org/mongo-driver/bson/primitive"
 
 type AnalysisWrapper struct {
-	Id                 primitive.ObjectID `json:"id" bson:"_id,omitempty"`
-	OrganisationId     string             `json:"organisationId" bson:"organisationId,omitempty"`
-	Key                string             `json:"key,omitempty"`
-	Provider           string             `json:"provider" bson:"provider"`
-	Source             string             `json:"source" bson:"source"`
-	InProcess          int64              `json:"in_process,omitempty"`
-	Timestamp          int64              `json:"timestamp,omitempty"`
-	Start              int64              `json:"start,omitempty"`
-	End                int64              `json:"end,omitempty"`
-	UserId             string             `json:"user_id,omitempty"`
-	DeviceId           string             `json:"device_id,omitempty"`
-	AsyncOperations    []string           `json:"asyncOperations,omitempty"`
-	RequiredOperations []string           `json:"requiredOperations,omitempty"`
-	ResolvedOperations []string           `json:"resolvedOperations,omitempty"`
-	Favourite          bool               `json:"favourite,omitempty"`
-	Data               Analysis           `json:"data,omitempty"`
+	Id             primitive.ObjectID `json:"id" bson:"_id,omitempty"`
+	OrganisationId string             `json:"organisationId" bson:"organisationId,omitempty"`
+
+	// ProjectId optionally places the analysis in a project within its organisation.
+	// A nil value keeps the analysis organisation-wide.
+	ProjectId *primitive.ObjectID `json:"projectId,omitempty" bson:"projectId,omitempty"`
+
+	Key                string   `json:"key,omitempty"`
+	Provider           string   `json:"provider" bson:"provider"`
+	Source             string   `json:"source" bson:"source"`
+	InProcess          int64    `json:"in_process,omitempty"`
+	Timestamp          int64    `json:"timestamp,omitempty"`
+	Start              int64    `json:"start,omitempty"`
+	End                int64    `json:"end,omitempty"`
+	UserId             string   `json:"user_id,omitempty"`
+	DeviceId           string   `json:"device_id,omitempty"`
+	AsyncOperations    []string `json:"asyncOperations,omitempty"`
+	RequiredOperations []string `json:"requiredOperations,omitempty"`
+	ResolvedOperations []string `json:"resolvedOperations,omitempty"`
+	Favourite          bool     `json:"favourite,omitempty"`
+	Data               Analysis `json:"data,omitempty"`
 }
 
 type AnalysisShort struct {

--- a/pkg/models/case_attachment.go
+++ b/pkg/models/case_attachment.go
@@ -25,6 +25,10 @@ type CaseAttachment struct {
 	TaskId         primitive.ObjectID `json:"taskId"         bson:"task_id"`
 	OrganisationId string             `json:"organisationId" bson:"organisation_id"`
 
+	// ProjectId optionally places the attachment in a project within its organisation.
+	// A nil value keeps it organisation-wide.
+	ProjectId *primitive.ObjectID `json:"projectId,omitempty" bson:"projectId,omitempty"`
+
 	// Type is a coarse classification of the attachment used by the UI
 	// to pick an icon / viewer. MimeType is the source of truth for
 	// content negotiation; Type is derived from it at upload time.

--- a/pkg/models/case_media.go
+++ b/pkg/models/case_media.go
@@ -22,6 +22,10 @@ type CaseMedia struct {
 	TaskId         primitive.ObjectID `json:"taskId" bson:"task_id"`
 	OrganisationId string             `json:"organisationId" bson:"organisation_id"`
 
+	// ProjectId optionally places the case media in a project within its organisation.
+	// A nil value keeps it organisation-wide.
+	ProjectId *primitive.ObjectID `json:"projectId,omitempty" bson:"projectId,omitempty"`
+
 	// Role describes whether this entry represents a source attached to
 	// the case or an edit derived from another entry. See CaseMediaRole.
 	Role CaseMediaRole `json:"role" bson:"role"`

--- a/pkg/models/case_share.go
+++ b/pkg/models/case_share.go
@@ -8,15 +8,20 @@ type CaseShare struct {
 	UserId         string             `json:"user_id" bson:"user_id"`
 	UserEmail      string             `json:"user_email" bson:"user_email"`
 	OrganisationId string             `json:"organisation_id" bson:"organisation_id"`
-	Email          string             `json:"email" bson:"email"`
-	Token          string             `json:"token" bson:"token"`
-	Permissions    []string           `json:"permissions" bson:"permissions"` // e.g. ["view"]
-	IsActive       bool               `json:"is_active" bson:"is_active"`
-	ExpiresAt      int64              `json:"expires_at" bson:"expires_at"`
-	CreatedAt      int64              `json:"created_at" bson:"created_at"`
-	OTPCode        string             `json:"-" bson:"otp_code,omitempty"`
-	OTPExpiry      int64              `json:"-" bson:"otp_expiry,omitempty"`
-	OTPAttempts    int                `json:"-" bson:"otp_attempts,omitempty"`
+
+	// ProjectId optionally places the case share in a project within its organisation.
+	// A nil value keeps it organisation-wide.
+	ProjectId *primitive.ObjectID `json:"projectId,omitempty" bson:"projectId,omitempty"`
+
+	Email       string   `json:"email" bson:"email"`
+	Token       string   `json:"token" bson:"token"`
+	Permissions []string `json:"permissions" bson:"permissions"` // e.g. ["view"]
+	IsActive    bool     `json:"is_active" bson:"is_active"`
+	ExpiresAt   int64    `json:"expires_at" bson:"expires_at"`
+	CreatedAt   int64    `json:"created_at" bson:"created_at"`
+	OTPCode     string   `json:"-" bson:"otp_code,omitempty"`
+	OTPExpiry   int64    `json:"-" bson:"otp_expiry,omitempty"`
+	OTPAttempts int      `json:"-" bson:"otp_attempts,omitempty"`
 
 	// Selection is the per-share snapshot of the case_media ids the
 	// recipient is allowed to browse, captured at CreateShare time.

--- a/pkg/models/comment.go
+++ b/pkg/models/comment.go
@@ -11,6 +11,10 @@ type Comment struct {
 	DeviceId       string `json:"deviceId" bson:"deviceId,omitempty"` // device identifier
 	OrganisationId string `json:"organisationId" bson:"organisationId,omitempty"`
 
+	// ProjectId optionally places the comment in a project within its organisation.
+	// A nil value keeps the comment organisation-wide.
+	ProjectId *primitive.ObjectID `json:"projectId,omitempty" bson:"projectId,omitempty"`
+
 	// Comment information
 	Type       string  `json:"type" bson:"type,omitempty"`
 	Author     string  `json:"author" bson:"author,omitempty"`

--- a/pkg/models/device.go
+++ b/pkg/models/device.go
@@ -38,6 +38,11 @@ type Device struct {
 	SiteIds        []string `json:"siteIds" bson:"siteIds,omitempty"`
 	GroupIds       []string `json:"groupIds" bson:"groupIds,omitempty"`
 
+	// ProjectId optionally places the device in a project within its
+	// organisation. A nil value keeps the device organisation-wide. It narrows
+	// access on top of OrganisationId; it never replaces it.
+	ProjectId *primitive.ObjectID `json:"projectId,omitempty" bson:"projectId,omitempty"`
+
 	// @LEGACY FIELDS - to be removed in future versions
 	UserId string `json:"user_id" bson:"user_id,omitempty"`
 

--- a/pkg/models/group.go
+++ b/pkg/models/group.go
@@ -14,6 +14,10 @@ type Group struct {
 	Groups         []string `json:"groups" bson:"groups"` // Nested groups
 	Sites          []string `json:"sites" bson:"sites"`   // Nested sites
 
+	// ProjectId optionally places the group in a project within its organisation.
+	// A nil value keeps the group organisation-wide.
+	ProjectId *primitive.ObjectID `json:"projectId,omitempty" bson:"projectId,omitempty"`
+
 	// Media file information (by default "vault", however might change
 	// in the future (integration with other storage solutions, next to Vault).
 	StorageSolution string `json:"storageSolution,omitempty" bson:"storageSolution,omitempty"`

--- a/pkg/models/io.go
+++ b/pkg/models/io.go
@@ -3,15 +3,20 @@ package models
 import "go.mongodb.org/mongo-driver/bson/primitive"
 
 type IO struct {
-	Id                primitive.ObjectID `json:"id" bson:"_id,omitempty"`
-	OrganisationId    string             `json:"organisationId" bson:"organisationId,omitempty"`
-	Hash              string             `json:"hash" bson:"hash,omitempty"`
-	DeviceId          string             `json:"deviceId" bson:"deviceId,omitempty"` // device identifier
-	Type              string             `json:"type" bson:"type,omitempty"`         // input or output
-	Key               string             `json:"key" bson:"key,omitempty"`
-	Value             string             `json:"value" bson:"value,omitempty"`
-	LastSeenTimestamp int64              `json:"lastSeenTimestamp" bson:"lastSeenTimestamp,omitempty"` // last time the IO was seen
-	External          bool               `json:"external" bson:"external,omitempty"`
+	Id             primitive.ObjectID `json:"id" bson:"_id,omitempty"`
+	OrganisationId string             `json:"organisationId" bson:"organisationId,omitempty"`
+
+	// ProjectId optionally places the IO in a project within its organisation.
+	// A nil value keeps the IO organisation-wide.
+	ProjectId *primitive.ObjectID `json:"projectId,omitempty" bson:"projectId,omitempty"`
+
+	Hash              string `json:"hash" bson:"hash,omitempty"`
+	DeviceId          string `json:"deviceId" bson:"deviceId,omitempty"` // device identifier
+	Type              string `json:"type" bson:"type,omitempty"`         // input or output
+	Key               string `json:"key" bson:"key,omitempty"`
+	Value             string `json:"value" bson:"value,omitempty"`
+	LastSeenTimestamp int64  `json:"lastSeenTimestamp" bson:"lastSeenTimestamp,omitempty"` // last time the IO was seen
+	External          bool   `json:"external" bson:"external,omitempty"`
 
 	// Audit information
 	Audit *Audit `json:"audit,omitempty" bson:"audit,omitempty"`

--- a/pkg/models/label.go
+++ b/pkg/models/label.go
@@ -15,6 +15,10 @@ type Label struct {
 	IsPrivate      bool               `json:"is_private" bson:"is_private"`
 	Types          []string           `json:"type" bson:"type,omitempty"`
 
+	// ProjectId optionally places the label in a project within its organisation.
+	// A nil value keeps the label organisation-wide.
+	ProjectId *primitive.ObjectID `json:"projectId,omitempty" bson:"projectId,omitempty"`
+
 	UserId    string `json:"user_id" bson:"user_id,omitempty"`
 	OwnerId   string `json:"owner_id" bson:"owner_id,omitempty"`
 	CreatedAt int64  `json:"created_at" bson:"created_at,omitempty"`

--- a/pkg/models/marker.go
+++ b/pkg/models/marker.go
@@ -14,6 +14,10 @@ type Marker struct {
 	GroupId        string `json:"groupId,omitempty" bson:"groupId,omitempty" example:"686a906345c1df594pmt41w4"`  // GroupId is used to identify the group of markers
 	OrganisationId string `json:"organisationId" bson:"organisationId" example:"686a906345c1df594pad69f0"`        // OrganisationId is used to identify the organisation that owns the marker, retrieved from the user's access token
 
+	// ProjectId optionally places the marker in a project within its organisation.
+	// A nil value keeps the marker organisation-wide.
+	ProjectId *primitive.ObjectID `json:"projectId,omitempty" bson:"projectId,omitempty"`
+
 	// MediaKeys optionally pins this marker to specific recordings by their stable
 	// key (media.videoFile). When set, the marker writer links the marker to
 	// exactly these recordings — scoped to the marker's device and organisation —
@@ -110,7 +114,7 @@ type MarkerBox struct {
 // duplicated here.
 type DetectionRef struct {
 	RunId   string `json:"runId" bson:"runId" example:"01J8Z9Q2A7K3"` // DetectionRun.Source.RunId
-	TrackId string `json:"trackId" bson:"trackId" example:"track-3"` // FaceRedactionTrack.Id within the run
+	TrackId string `json:"trackId" bson:"trackId" example:"track-3"`  // FaceRedactionTrack.Id within the run
 }
 
 type MarkerAtRuntimeMetadata struct {

--- a/pkg/models/media.go
+++ b/pkg/models/media.go
@@ -23,6 +23,10 @@ type Media struct {
 	SiteId         string `json:"siteId" bson:"siteId,omitempty"`
 	OrganisationId string `json:"organisationId" bson:"organisationId,omitempty"`
 
+	// ProjectId optionally places the media in a project within its organisation.
+	// A nil value keeps the media organisation-wide.
+	ProjectId *primitive.ObjectID `json:"projectId,omitempty" bson:"projectId,omitempty"`
+
 	// Media file information (by default "vault", however might change
 	// in the future (integration with other storage solutions, next to Vault).
 	StorageSolution       string                  `json:"storageSolution,omitempty" bson:"storageSolution,omitempty"`

--- a/pkg/models/message.go
+++ b/pkg/models/message.go
@@ -1,39 +1,44 @@
 package models
 
+import "go.mongodb.org/mongo-driver/bson/primitive"
+
 type Message struct {
-	Type              string            `json:"type,omitempty" bson:"type,omitempty"`
-	Id                string            `json:"id,omitempty" bson:"id,omitempty"`
-	OrganisationId    string            `json:"organisationId,omitempty" bson:"organisationId,omitempty"`
-	AlertId           string            `json:"alert_id,omitempty" bson:"alert_id,omitempty"`
-	AlertName         string            `json:"alert_name,omitempty" bson:"alert_name,omitempty"`
-	AlertUser         string            `json:"alert_user,omitempty" bson:"alert_user,omitempty"`
-	AlertMasterUser   string            `json:"alert_master_user,omitempty" bson:"alert_master_user,omitempty"`
-	Timestamp         int64             `json:"timestamp,omitempty" bson:"timestamp,omitempty"`
-	NotificationType  string            `json:"notification_type,omitempty" bson:"notification_type,omitempty"` // generic, counting, region
-	Title             string            `json:"title,omitempty" bson:"title,omitempty"`
-	Body              string            `json:"body,omitempty" bson:"body,omitempty"`
-	Unread            bool              `json:"unread,omitempty" bson:"unread,omitempty"`
-	User              string            `json:"user,omitempty" bson:"user,omitempty"`
-	UserId            string            `json:"userid,omitempty" bson:"userid,omitempty"`
-	Timezone          string            `json:"timezone,omitempty" bson:"timezone,omitempty"`
-	Email             string            `json:"email,omitempty" bson:"email,omitempty"`
-	SequenceId        string            `json:"sequence_id,omitempty" bson:"sequence_id,omitempty"`
-	Thumbnail         string            `json:"thumbnail,omitempty" bson:"thumbnail,omitempty"`
-	ThumbnailFile     string            `json:"thumbnailFile,omitempty" bson:"thumbnailFile,omitempty"`
-	ThumbnailProvider string            `json:"thumbnailProvider,omitempty" bson:"thumbnailProvider,omitempty"`
-	SpriteFile        string            `json:"spriteFile,omitempty" bson:"spriteFile,omitempty"`
-	SpriteInterval    int               `json:"spriteInterval,omitempty" bson:"spriteInterval,omitempty"`
-	SpriteProvider    string            `json:"spriteProvider,omitempty" bson:"spriteProvider,omitempty"`
-	DeviceId          string            `json:"device_id,omitempty" bson:"device_id,omitempty"`
-	DeviceName        string            `json:"device_name,omitempty" bson:"device_name,omitempty"`
-	Classifications   []string          `json:"classifications,omitempty" bson:"classifications,omitempty"`
-	Sites             []Site            `json:"sites,omitempty" bson:"sites,omitempty"`
-	Groups            []Group           `json:"groups,omitempty" bson:"groups,omitempty"`
-	MediaKey          string            `json:"media_key,omitempty" bson:"media_key,omitempty"`
-	MediaProvider     string            `json:"media_provider,omitempty" bson:"media_provider,omitempty"`
-	MediaSource       string            `json:"media_source,omitempty" bson:"media_source,omitempty"`
-	Media             []Media           `json:"media,omitempty" bson:"media,omitempty"`
-	NumberOfMedia     string            `json:"number_of_media,omitempty" bson:"number_of_media,omitempty"`
-	DataUsage         string            `json:"data_usage,omitempty" bson:"data_usage,omitempty"`
-	Data              map[string]string `json:"data,omitempty" bson:"data,omitempty"`
+	Type           string `json:"type,omitempty" bson:"type,omitempty"`
+	Id             string `json:"id,omitempty" bson:"id,omitempty"`
+	OrganisationId string `json:"organisationId,omitempty" bson:"organisationId,omitempty"`
+	// ProjectId optionally places the message in a project within its organisation.
+	// A nil value keeps the message organisation-wide.
+	ProjectId         *primitive.ObjectID `json:"projectId,omitempty" bson:"projectId,omitempty"`
+	AlertId           string              `json:"alert_id,omitempty" bson:"alert_id,omitempty"`
+	AlertName         string              `json:"alert_name,omitempty" bson:"alert_name,omitempty"`
+	AlertUser         string              `json:"alert_user,omitempty" bson:"alert_user,omitempty"`
+	AlertMasterUser   string              `json:"alert_master_user,omitempty" bson:"alert_master_user,omitempty"`
+	Timestamp         int64               `json:"timestamp,omitempty" bson:"timestamp,omitempty"`
+	NotificationType  string              `json:"notification_type,omitempty" bson:"notification_type,omitempty"` // generic, counting, region
+	Title             string              `json:"title,omitempty" bson:"title,omitempty"`
+	Body              string              `json:"body,omitempty" bson:"body,omitempty"`
+	Unread            bool                `json:"unread,omitempty" bson:"unread,omitempty"`
+	User              string              `json:"user,omitempty" bson:"user,omitempty"`
+	UserId            string              `json:"userid,omitempty" bson:"userid,omitempty"`
+	Timezone          string              `json:"timezone,omitempty" bson:"timezone,omitempty"`
+	Email             string              `json:"email,omitempty" bson:"email,omitempty"`
+	SequenceId        string              `json:"sequence_id,omitempty" bson:"sequence_id,omitempty"`
+	Thumbnail         string              `json:"thumbnail,omitempty" bson:"thumbnail,omitempty"`
+	ThumbnailFile     string              `json:"thumbnailFile,omitempty" bson:"thumbnailFile,omitempty"`
+	ThumbnailProvider string              `json:"thumbnailProvider,omitempty" bson:"thumbnailProvider,omitempty"`
+	SpriteFile        string              `json:"spriteFile,omitempty" bson:"spriteFile,omitempty"`
+	SpriteInterval    int                 `json:"spriteInterval,omitempty" bson:"spriteInterval,omitempty"`
+	SpriteProvider    string              `json:"spriteProvider,omitempty" bson:"spriteProvider,omitempty"`
+	DeviceId          string              `json:"device_id,omitempty" bson:"device_id,omitempty"`
+	DeviceName        string              `json:"device_name,omitempty" bson:"device_name,omitempty"`
+	Classifications   []string            `json:"classifications,omitempty" bson:"classifications,omitempty"`
+	Sites             []Site              `json:"sites,omitempty" bson:"sites,omitempty"`
+	Groups            []Group             `json:"groups,omitempty" bson:"groups,omitempty"`
+	MediaKey          string              `json:"media_key,omitempty" bson:"media_key,omitempty"`
+	MediaProvider     string              `json:"media_provider,omitempty" bson:"media_provider,omitempty"`
+	MediaSource       string              `json:"media_source,omitempty" bson:"media_source,omitempty"`
+	Media             []Media             `json:"media,omitempty" bson:"media,omitempty"`
+	NumberOfMedia     string              `json:"number_of_media,omitempty" bson:"number_of_media,omitempty"`
+	DataUsage         string              `json:"data_usage,omitempty" bson:"data_usage,omitempty"`
+	Data              map[string]string   `json:"data,omitempty" bson:"data,omitempty"`
 }

--- a/pkg/models/project.go
+++ b/pkg/models/project.go
@@ -13,3 +13,39 @@ type Project struct {
 	IsActive       bool               `json:"isActive" bson:"isActive"`
 	Audit          Audit              `json:"audit" bson:"audit"`
 }
+
+// DefaultProjectSlug is the reserved slug of the single default project minted
+// per organisation. The default project is the sentinel-free "organisation-wide"
+// selection: it is a real document (never a stored NilObjectID) so a user's
+// active project can always point at something concrete.
+const DefaultProjectSlug = "default"
+
+// GetProjectsInput lists the projects in the caller's active organisation.
+type GetProjectsInput struct {
+	User User `json:"user"`
+}
+
+type GetProjectsOutput struct {
+	Projects []Project `json:"projects"`
+}
+
+// GetCurrentProjectInput resolves the caller's active project (the one whose id
+// equals the caller's projectId, or the organisation default when unset).
+type GetCurrentProjectInput struct {
+	User User `json:"user"`
+}
+
+type GetCurrentProjectOutput struct {
+	Project *Project `json:"project"`
+}
+
+// SetCurrentProjectInput selects the project used to scope subsequent requests
+// for the caller. The project must belong to the caller's active organisation.
+type SetCurrentProjectInput struct {
+	User      User   `json:"user"`
+	ProjectId string `json:"projectId"`
+}
+
+type SetCurrentProjectOutput struct {
+	Project *Project `json:"project"`
+}

--- a/pkg/models/project.go
+++ b/pkg/models/project.go
@@ -3,7 +3,7 @@ package models
 import "go.mongodb.org/mongo-driver/bson/primitive"
 
 // Project is an optional access boundary within an organisation. Resources
-// remain organisation-wide unless they are assigned a ProjectResourceScope.
+// remain organisation-wide unless their ProjectId is set.
 type Project struct {
 	Id             primitive.ObjectID `json:"id" bson:"_id,omitempty"`
 	OrganisationId primitive.ObjectID `json:"organisationId" bson:"organisationId"`
@@ -12,17 +12,4 @@ type Project struct {
 	Description    string             `json:"description,omitempty" bson:"description,omitempty"`
 	IsActive       bool               `json:"isActive" bson:"isActive"`
 	Audit          Audit              `json:"audit" bson:"audit"`
-}
-
-// ProjectResourceScope optionally places a resource in one owning project and
-// shares it with additional projects. A nil ProjectId keeps the resource at
-// organisation scope; SharedWithProjectIds must then be empty.
-type ProjectResourceScope struct {
-	ProjectId            *primitive.ObjectID  `json:"projectId,omitempty" bson:"projectId,omitempty"`
-	SharedWithProjectIds []primitive.ObjectID `json:"sharedWithProjectIds,omitempty" bson:"sharedWithProjectIds,omitempty"`
-}
-
-// IsOrganisationWide reports whether the resource remains at organisation scope.
-func (s ProjectResourceScope) IsOrganisationWide() bool {
-	return s.ProjectId == nil
 }

--- a/pkg/models/project_test.go
+++ b/pkg/models/project_test.go
@@ -3,33 +3,64 @@ package models
 import (
 	"testing"
 
+	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
-
-func TestProjectResourceScopeIsOrganisationWide(t *testing.T) {
-	projectId := primitive.NewObjectID()
-
-	tests := []struct {
-		name  string
-		scope ProjectResourceScope
-		want  bool
-	}{
-		{name: "unassigned", scope: ProjectResourceScope{}, want: true},
-		{name: "assigned", scope: ProjectResourceScope{ProjectId: &projectId}, want: false},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			if got := test.scope.IsOrganisationWide(); got != test.want {
-				t.Fatalf("IsOrganisationWide() = %v, want %v", got, test.want)
-			}
-		})
-	}
-}
 
 func TestRoleAssignmentScopeWithProjectsIsNotOrganisationWide(t *testing.T) {
 	scope := RoleAssignmentScope{ProjectIds: []primitive.ObjectID{primitive.NewObjectID()}}
 	if scope.IsOrganisationWide() {
 		t.Fatal("project-scoped role assignment must not be organisation-wide")
 	}
+}
+
+// TestProjectScopedResourceBSONContracts pins the flat ProjectId field to a
+// top-level projectId key on every project-scoped resource, so
+// database.ProjectScope (which matches that exact top-level key) stays in
+// lock-step with the model. It also asserts an unset ProjectId stays
+// organisation-wide (no projectId key), which is why no historical backfill is
+// required.
+func TestProjectScopedResourceBSONContracts(t *testing.T) {
+	projectId := primitive.NewObjectID()
+
+	build := func(assign func(*primitive.ObjectID) any) (assigned bson.M, unset bson.M) {
+		return marshalM(assign(&projectId)), marshalM(assign(nil))
+	}
+
+	tests := []struct {
+		name   string
+		assign func(*primitive.ObjectID) any
+	}{
+		{name: "Device", assign: func(p *primitive.ObjectID) any { return Device{ProjectId: p} }},
+		{name: "Site", assign: func(p *primitive.ObjectID) any { return Site{ProjectId: p} }},
+		{name: "Group", assign: func(p *primitive.ObjectID) any { return Group{ProjectId: p} }},
+		{name: "Label", assign: func(p *primitive.ObjectID) any { return Label{ProjectId: p} }},
+		{name: "IO", assign: func(p *primitive.ObjectID) any { return IO{ProjectId: p} }},
+		{name: "Videowall", assign: func(p *primitive.ObjectID) any { return Videowall{ProjectId: p} }},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assigned, unset := build(test.assign)
+
+			if assigned["projectId"] != projectId {
+				t.Fatalf("assigned projectId = %v, want %s", assigned["projectId"], projectId.Hex())
+			}
+			if _, exists := unset["projectId"]; exists {
+				t.Fatal("organisation-wide resource must not carry a projectId")
+			}
+		})
+	}
+}
+
+func marshalM(v any) bson.M {
+	encoded, err := bson.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	var document bson.M
+	if err := bson.Unmarshal(encoded, &document); err != nil {
+		panic(err)
+	}
+	return document
 }

--- a/pkg/models/sequence.go
+++ b/pkg/models/sequence.go
@@ -3,13 +3,18 @@ package models
 import "go.mongodb.org/mongo-driver/bson/primitive"
 
 type Sequence struct {
-	Id             primitive.ObjectID     `json:"id" bson:"_id,omitempty"`
-	OrganisationId string                 `json:"organisationId" bson:"organisationId,omitempty"`
-	Start          int64                  `json:"start,omitempty"`
-	End            int64                  `json:"end,omitempty"`
-	UserId         string                 `json:"user_id" bson:"user_id,omitempty"`
-	Images         []Media                `json:"images,omitempty"`
-	Analysis       map[string]interface{} `bson:"analysis,omitempty"`
-	Devices        []string               `json:"devices,omitempty"`
-	Notified       bool                   `json:"notified,omitempty"`
+	Id             primitive.ObjectID `json:"id" bson:"_id,omitempty"`
+	OrganisationId string             `json:"organisationId" bson:"organisationId,omitempty"`
+
+	// ProjectId optionally places the sequence in a project within its organisation.
+	// A nil value keeps the sequence organisation-wide.
+	ProjectId *primitive.ObjectID `json:"projectId,omitempty" bson:"projectId,omitempty"`
+
+	Start    int64                  `json:"start,omitempty"`
+	End      int64                  `json:"end,omitempty"`
+	UserId   string                 `json:"user_id" bson:"user_id,omitempty"`
+	Images   []Media                `json:"images,omitempty"`
+	Analysis map[string]interface{} `bson:"analysis,omitempty"`
+	Devices  []string               `json:"devices,omitempty"`
+	Notified bool                   `json:"notified,omitempty"`
 }

--- a/pkg/models/site.go
+++ b/pkg/models/site.go
@@ -12,6 +12,10 @@ type Site struct {
 	Devices        []string `json:"devices" bson:"devices"`
 	Groups         []string `json:"groups" bson:"groups"`
 
+	// ProjectId optionally places the site in a project within its organisation.
+	// A nil value keeps the site organisation-wide.
+	ProjectId *primitive.ObjectID `json:"projectId,omitempty" bson:"projectId,omitempty"`
+
 	// Media file information (by default "vault", however might change
 	// in the future (integration with other storage solutions, next to Vault).
 	StorageSolution string `json:"storageSolution,omitempty" bson:"storageSolution,omitempty"`

--- a/pkg/models/state.go
+++ b/pkg/models/state.go
@@ -25,11 +25,12 @@ type State struct {
 	Description string             `json:"description,omitempty" bson:"description,omitempty" example:"Person forcably opened a door"` // Description of the status
 
 	// Resource identification, to which this state applies
-	DeviceId       string   `json:"deviceId" bson:"deviceId" example:"686a906345c1df594939f9j25f4"`                                                         // DeviceId is used to identify the device associated with the state
-	SiteId         string   `json:"siteId,omitempty" bson:"siteId,omitempty" example:"686a906345c1df594pcsr3r45"`                                           // SiteId is used to identify the site for which the state is relevant
-	GroupId        string   `json:"groupId,omitempty" bson:"groupId,omitempty" example:"686a906345c1df594pmt41w4"`                                          // GroupId is used to identify the group for which the state is relevant
-	OrganisationId string   `json:"organisationId" bson:"organisationId" example:"686a906345c1df594pad69f0"`                                                // OrganisationId is used to identify the organisation that owns the state.
-	Devices        []string `json:"devices,omitempty" bson:"devices,omitempty" example:"[\"686a906345c1df594939f9j25f4\",\"686a906345c1df594939f9j25f5\"]"` // List of device IDs associated with the state
+	DeviceId       string              `json:"deviceId" bson:"deviceId" example:"686a906345c1df594939f9j25f4"`                                                         // DeviceId is used to identify the device associated with the state
+	SiteId         string              `json:"siteId,omitempty" bson:"siteId,omitempty" example:"686a906345c1df594pcsr3r45"`                                           // SiteId is used to identify the site for which the state is relevant
+	GroupId        string              `json:"groupId,omitempty" bson:"groupId,omitempty" example:"686a906345c1df594pmt41w4"`                                          // GroupId is used to identify the group for which the state is relevant
+	OrganisationId string              `json:"organisationId" bson:"organisationId" example:"686a906345c1df594pad69f0"`                                                // OrganisationId is used to identify the organisation that owns the state.
+	ProjectId      *primitive.ObjectID `json:"projectId,omitempty" bson:"projectId,omitempty"`                                                                         // ProjectId optionally places the state in a project within its organisation; nil keeps it organisation-wide.
+	Devices        []string            `json:"devices,omitempty" bson:"devices,omitempty" example:"[\"686a906345c1df594939f9j25f4\",\"686a906345c1df594939f9j25f5\"]"` // List of device IDs associated with the state
 
 	// Timing information (all timestamps are in seconds)
 	DesiredState               StateEnum `json:"desiredState,omitempty" bson:"desiredState,omitempty" example:"active"`                                 // The desired state to be applied to the device

--- a/pkg/models/task.go
+++ b/pkg/models/task.go
@@ -25,25 +25,30 @@ type TaskStatistics struct {
 }
 
 type Task struct {
-	Id                primitive.ObjectID `json:"id" bson:"_id,omitempty"`
-	OrganisationId    string             `json:"organisationId" bson:"organisationId,omitempty"`
-	CreationDate      int64              `json:"creation_date" bson:"creation_date,omitempty"`
-	CreationDateTime  string             `json:"creation_datetime" bson:"creation_datetime,omitempty"`
-	Date              int64              `json:"date" bson:"date,omitempty"`
-	MediaTimestamp    int64              `json:"media_timestamp" bson:"media_timestamp,omitempty"`
-	MediaDate         string             `json:"media_date" bson:"media_date,omitempty"`
-	MediaDateTime     string             `json:"media_datetime" bson:"media_datetime,omitempty"`
-	MediaEndTimestamp int64              `json:"media_end_timestamp" bson:"media_end_timestamp,omitempty"`
-	MediaEndDateTime  string             `json:"media_end_datetime" bson:"media_end_datetime,omitempty"`
-	UserId            string             `json:"user_id" bson:"user_id,omitempty"`
-	Username          string             `json:"username" bson:"username,omitempty"`
-	ReporterId        string             `json:"reporter_id" bson:"reporter_id,omitempty"`
-	Title             string             `json:"title" bson:"title,omitempty"`
-	Notes             string             `json:"notes" bson:"notes,omitempty"`
-	NotesShort        string             `json:"notes_short" bson:"notes_short,omitempty"`
-	Status            string             `json:"status" bson:"status,omitempty"` // open, approved, rejected
-	SequenceId        string             `json:"sequenceId" bson:"sequenceId,omitempty"`
-	IsPrivate         bool               `json:"is_private" bson:"is_private"`
+	Id             primitive.ObjectID `json:"id" bson:"_id,omitempty"`
+	OrganisationId string             `json:"organisationId" bson:"organisationId,omitempty"`
+
+	// ProjectId optionally places the case/task in a project within its organisation.
+	// A nil value keeps it organisation-wide.
+	ProjectId *primitive.ObjectID `json:"projectId,omitempty" bson:"projectId,omitempty"`
+
+	CreationDate      int64  `json:"creation_date" bson:"creation_date,omitempty"`
+	CreationDateTime  string `json:"creation_datetime" bson:"creation_datetime,omitempty"`
+	Date              int64  `json:"date" bson:"date,omitempty"`
+	MediaTimestamp    int64  `json:"media_timestamp" bson:"media_timestamp,omitempty"`
+	MediaDate         string `json:"media_date" bson:"media_date,omitempty"`
+	MediaDateTime     string `json:"media_datetime" bson:"media_datetime,omitempty"`
+	MediaEndTimestamp int64  `json:"media_end_timestamp" bson:"media_end_timestamp,omitempty"`
+	MediaEndDateTime  string `json:"media_end_datetime" bson:"media_end_datetime,omitempty"`
+	UserId            string `json:"user_id" bson:"user_id,omitempty"`
+	Username          string `json:"username" bson:"username,omitempty"`
+	ReporterId        string `json:"reporter_id" bson:"reporter_id,omitempty"`
+	Title             string `json:"title" bson:"title,omitempty"`
+	Notes             string `json:"notes" bson:"notes,omitempty"`
+	NotesShort        string `json:"notes_short" bson:"notes_short,omitempty"`
+	Status            string `json:"status" bson:"status,omitempty"` // open, approved, rejected
+	SequenceId        string `json:"sequenceId" bson:"sequenceId,omitempty"`
+	IsPrivate         bool   `json:"is_private" bson:"is_private"`
 
 	// A task can be assigned to a single camera or multiple cameras (depending of the export)
 	Camera      string   `json:"camera" bson:"camera"`             // this is legacy we know use the array object.

--- a/pkg/models/user.go
+++ b/pkg/models/user.go
@@ -43,9 +43,19 @@ func GetOrganisationObjectId(user User) primitive.ObjectID {
 	return user.Id
 }
 
+// GetProjectObjectId returns the user's currently selected project, or the zero
+// ObjectID when no project is active. Unlike GetOrganisationObjectId there is no
+// fallback chain: a zero value is a valid, first-class state meaning "no active
+// project" (the organisation-wide view). Projects are net-new, so there is no
+// legacy identity to fall back to.
+func GetProjectObjectId(user User) primitive.ObjectID {
+	return user.ProjectId
+}
+
 type User struct {
 	Id                    primitive.ObjectID     `json:"id" bson:"_id,omitempty"`
 	OrganisationId        primitive.ObjectID     `json:"organisationId" bson:"organisationId,omitempty"`
+	ProjectId             primitive.ObjectID     `json:"projectId" bson:"projectId,omitempty"`
 	Username              string                 `json:"username" bson:"username,omitempty"`
 	Password              string                 `json:"password" bson:"password,omitempty"`
 	ForgotPassword        string                 `json:"forgotPassword" bson:"forgotPassword,omitempty"`

--- a/pkg/models/videowall.go
+++ b/pkg/models/videowall.go
@@ -9,20 +9,25 @@ import (
 type Videowall struct {
 	Id             primitive.ObjectID `json:"id" bson:"_id,omitempty"`
 	OrganisationId string             `json:"organisationId" bson:"organisationId,omitempty"`
-	Name           string             `json:"name" bson:"name,omitempty"`
-	Description    string             `json:"description" bson:"description,omitempty"`
-	Sites          []string           `json:"sites" bson:"sites"`
-	Groups         []string           `json:"groups" bson:"groups"`
-	Cameras        []string           `json:"cameras" bson:"cameras"`
-	IsActive       int                `json:"isActive" bson:"isActive"`
-	UserId         string             `json:"user_id" bson:"user_id"`
-	Username       string             `json:"username" bson:"username,omitempty"`
-	MasterUserId   string             `json:"master_user_id" bson:"master_user_id"`
-	PassCode       string             `json:"pass_code" bson:"pass_code"`
-	Fingerprint    string             `json:"fingerprint" bson:"fingerprint"`
-	ShortLink      string             `json:"short_link" bson:"short_link,omitempty"`
-	Header         int                `json:"header" bson:"header"`
-	Expiration     int64              `json:"expiration" bson:"expiration"`
+
+	// ProjectId optionally places the videowall in a project within its
+	// organisation. A nil value keeps it organisation-wide.
+	ProjectId *primitive.ObjectID `json:"projectId,omitempty" bson:"projectId,omitempty"`
+
+	Name         string   `json:"name" bson:"name,omitempty"`
+	Description  string   `json:"description" bson:"description,omitempty"`
+	Sites        []string `json:"sites" bson:"sites"`
+	Groups       []string `json:"groups" bson:"groups"`
+	Cameras      []string `json:"cameras" bson:"cameras"`
+	IsActive     int      `json:"isActive" bson:"isActive"`
+	UserId       string   `json:"user_id" bson:"user_id"`
+	Username     string   `json:"username" bson:"username,omitempty"`
+	MasterUserId string   `json:"master_user_id" bson:"master_user_id"`
+	PassCode     string   `json:"pass_code" bson:"pass_code"`
+	Fingerprint  string   `json:"fingerprint" bson:"fingerprint"`
+	ShortLink    string   `json:"short_link" bson:"short_link,omitempty"`
+	Header       int      `json:"header" bson:"header"`
+	Expiration   int64    `json:"expiration" bson:"expiration"`
 	//ForceMFA    int      `json:"force_mfa" bson:"force_mfa"`
 	PTZ            int               `json:"ptz" bson:"ptz"`
 	Liveview       int               `json:"liveview" bson:"liveview"`

--- a/pkg/models/workflow.go
+++ b/pkg/models/workflow.go
@@ -359,8 +359,11 @@ type Workflow struct {
 	// materially used in deployments, so new documents start with this canonical
 	// contract while readers may retain a legacy `organisation_id` fallback.
 	OrganisationId string `json:"organisationId" bson:"organisationId,omitempty"`
-	CreatedAt      int64  `json:"createdAt" bson:"createdAt,omitempty"`
-	UpdatedAt      int64  `json:"updatedAt" bson:"updatedAt,omitempty"`
+	// ProjectId optionally places the workflow in a project within its organisation.
+	// A nil value keeps the workflow organisation-wide.
+	ProjectId *primitive.ObjectID `json:"projectId,omitempty" bson:"projectId,omitempty"`
+	CreatedAt int64               `json:"createdAt" bson:"createdAt,omitempty"`
+	UpdatedAt int64               `json:"updatedAt" bson:"updatedAt,omitempty"`
 	// Audit carries bounded actor/timestamp metadata for database-backed user
 	// workflows. It is omitted from Helm-defined global workflows unless set.
 	Audit *Audit `json:"audit,omitempty" bson:"audit,omitempty"`

--- a/pkg/models/workflowrun.go
+++ b/pkg/models/workflowrun.go
@@ -191,6 +191,10 @@ type WorkflowRun struct {
 	// on the wire the same identity travels in the richer User projection.
 	OrganisationId string `json:"-" bson:"organisationId"`
 
+	// ProjectId optionally narrows the run to a project within its organisation.
+	// Persistence-only, like OrganisationId. A nil value keeps it organisation-wide.
+	ProjectId *primitive.ObjectID `json:"-" bson:"projectId,omitempty"`
+
 	// TraceId continues the distributed trace across the workflow tail.
 	TraceId string `json:"traceId,omitempty" bson:"traceid"`
 


### PR DESCRIPTION
## Description

This change introduces project-level sub-scoping across tenant-scoped models, enabling resources to be optionally assigned to a project while preserving existing organisation-wide behaviour.

Previously, resources were scoped only at the organisation level. Adding an optional `ProjectId` field to core models creates a consistent and lightweight way to narrow access, ownership, and filtering within the same tenant without breaking backwards compatibility. Resources with no `ProjectId` remain organisation-wide, so no migration or historical backfill is required.

The PR also adds project API DTOs and supporting project selection models, laying the groundwork for users to switch between organisation-wide and project-specific contexts in a predictable way. Introducing a concrete default project concept avoids sentinel values and keeps active project resolution explicit and stable.

The included BSON contract tests protect the persistence layer by ensuring every project-scoped resource serialises `projectId` consistently as a top-level field. This keeps database filtering logic aligned with the model definitions and reduces the risk of silent scoping regressions in future changes.

Overall, this improves the platform’s multi-project tenancy model while maintaining compatibility with existing organisation-scoped data and workflows.