### PR TITLE
feat(project): define the hidden default project scope

### DIFF
--- a/pkg/projectscope/projectscope.go
+++ b/pkg/projectscope/projectscope.go
@@ -1,0 +1,50 @@
+// Package projectscope defines which project owns an organisation's resources
+// during the hidden single-project rollout.
+//
+// The rollout has no project UI, no switcher, and no API surface, so there is
+// no authoritative record to consult: every organisation behaves as if it has
+// exactly one project. That makes the default a *definition* rather than a
+// lookup, and the distinction matters.
+//
+// A lookup — resolving the project by slug, by "first document", or by an
+// isActive flag — can return a different value in two services for the same
+// organisation. It diverges when one service is deployed ahead of another, when
+// a query orders results differently, or when the collection is empty on an
+// instance where the migration has not run. Derived resources would then be
+// stamped with projects their organisation's readers never select, and the
+// media would simply disappear from the UI.
+//
+// A pure function cannot diverge. It performs no I/O, so it returns the same
+// value on every instance regardless of deployment order or collection state,
+// and it produces exactly the value the project materialisation will persist.
+// Callers must therefore never "improve" these helpers by adding a query.
+package projectscope
+
+import "go.mongodb.org/mongo-driver/bson/primitive"
+
+// DefaultProjectId returns the project that owns an organisation's resources
+// while no project has been explicitly assigned.
+//
+// The default reuses the organisation id. That is not an arbitrary choice: it
+// makes the value derivable from data every service already holds, so no
+// service needs a project read to agree with the others, and it stays stable
+// once real projects are introduced because the default project is minted with
+// this id rather than a fresh one.
+func DefaultProjectId(organisationId primitive.ObjectID) primitive.ObjectID {
+	return organisationId
+}
+
+// ResolveProjectId returns the project owning a resource, preferring an
+// explicitly stored assignment over the organisation default.
+//
+// A stored project is an authoritative fact written by a service that knew the
+// resource's placement, so it wins. A nil or zero value means "not assigned",
+// not "assigned to nothing", and falls back to DefaultProjectId. Treating zero
+// as a real project would stamp derived resources with NilObjectID and hide
+// them from every project-scoped read.
+func ResolveProjectId(organisationId primitive.ObjectID, stored *primitive.ObjectID) primitive.ObjectID {
+	if stored != nil && !stored.IsZero() {
+		return *stored
+	}
+	return DefaultProjectId(organisationId)
+}

--- a/pkg/projectscope/projectscope_test.go
+++ b/pkg/projectscope/projectscope_test.go
@@ -1,0 +1,53 @@
+package projectscope
+
+import (
+	"testing"
+
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+func TestDefaultProjectIdReusesOrganisationId(t *testing.T) {
+	organisationId := primitive.NewObjectID()
+	if got := DefaultProjectId(organisationId); got != organisationId {
+		t.Fatalf("DefaultProjectId() = %s, want %s", got.Hex(), organisationId.Hex())
+	}
+}
+
+func TestDefaultProjectIdIsStable(t *testing.T) {
+	// Two independently deployed services calling this for the same
+	// organisation must agree. Nothing here may depend on state, so calling it
+	// repeatedly is the same as calling it from anywhere else.
+	organisationId := primitive.NewObjectID()
+	first := DefaultProjectId(organisationId)
+	for range 100 {
+		if got := DefaultProjectId(organisationId); got != first {
+			t.Fatalf("DefaultProjectId() = %s, want %s", got.Hex(), first.Hex())
+		}
+	}
+}
+
+func TestResolveProjectIdPrefersStoredAssignment(t *testing.T) {
+	organisationId := primitive.NewObjectID()
+	stored := primitive.NewObjectID()
+
+	if got := ResolveProjectId(organisationId, &stored); got != stored {
+		t.Fatalf("ResolveProjectId() = %s, want stored %s", got.Hex(), stored.Hex())
+	}
+}
+
+func TestResolveProjectIdFallsBackForUnassignedResources(t *testing.T) {
+	organisationId := primitive.NewObjectID()
+	zero := primitive.NilObjectID
+
+	// A nil pointer and a stored zero both mean "no project assigned". Neither
+	// may be treated as a real project, or the resource is stamped with
+	// NilObjectID and disappears from project-scoped reads.
+	for name, stored := range map[string]*primitive.ObjectID{
+		"nil":  nil,
+		"zero": &zero,
+	} {
+		if got := ResolveProjectId(organisationId, stored); got != organisationId {
+			t.Fatalf("ResolveProjectId(%s) = %s, want organisation default %s", name, got.Hex(), organisationId.Hex())
+		}
+	}
+}


### PR DESCRIPTION
## Description

This change introduces a dedicated `projectscope` package that defines how resources resolve to a project during the hidden single-project rollout.

The key motivation is consistency. During this rollout there is no project UI, API, or authoritative project selection mechanism, which means deriving a “default project” through database lookups is unsafe. Different services or deployment states could resolve different projects for the same organisation, causing resources to be written under mismatched scopes and disappear from project-scoped reads.

To prevent this, the default project is now defined as a pure function of the organisation ID. This guarantees that every service resolves the same project deterministically without depending on collection state, migration timing, query ordering, or deployment order.

The change also centralises fallback behaviour for unassigned resources through `ResolveProjectId`, ensuring that nil or zero-value project assignments safely resolve to the organisation default instead of producing invalid `NilObjectID` ownership.

Comprehensive tests were added to verify determinism, stability, and correct fallback semantics across deployments and edge cases.