### PR TITLE
adjust accesstoken

### DIFF
--- a/pkg/models/accesstoken.go
+++ b/pkg/models/accesstoken.go
@@ -19,8 +19,9 @@ type AccessToken struct {
 	Token       string             `json:"token,omitempty" bson:"token,omitempty"`             // The actual access token value, should be kept secret (will be trimmed before saving)
 
 	// RBAC information
-	OrganisationId string `json:"organisationId" bson:"organisationId,omitempty"` // OrganisationId is used to identify the organisation that owns the marker
-	UserId         string `json:"userId" bson:"userId,omitempty"`                 // UserId is used to identify the user that created the marker
+	OrganisationId string              `json:"organisationId" bson:"organisationId,omitempty"` // OrganisationId is used to identify the organisation that owns the marker
+	UserId         string              `json:"userId" bson:"userId,omitempty"`                 // UserId is used to identify the user that created the marker
+	ProjectId      *primitive.ObjectID `json:"-" bson:"projectId,omitempty"`
 
 	// Audit information
 	Audit *Audit `json:"audit,omitempty" bson:"audit,omitempty"` // Audit information for tracking changes to the access token

--- a/pkg/properties/accesstoken.go
+++ b/pkg/properties/accesstoken.go
@@ -13,5 +13,6 @@ const (
 	AccessTokenToken = "token"
 	AccessTokenOrganisationId = "organisationId"
 	AccessTokenUserId = "userId"
+	AccessTokenProjectId = "projectId"
 	AccessTokenAudit = "audit"
 )


### PR DESCRIPTION
## Description

This change extends the `AccessToken` model with an optional `ProjectId` reference and exposes the corresponding property constant for consistent usage across the codebase.

The motivation is to improve access token scoping and support project-level ownership and authorization flows in addition to the existing organisation and user associations. By introducing a dedicated `projectId` field at the model level, the project gains a clearer and more flexible RBAC structure that can support finer-grained access control and future multi-project features.

The field is stored in BSON but excluded from JSON responses, which helps preserve internal association details while still enabling efficient persistence and querying in MongoDB.