### PR TITLE
refactor(project): fold the project scope default into the models pac…

### DIFF
--- a/pkg/models/projectscope.go
+++ b/pkg/models/projectscope.go
@@ -1,4 +1,8 @@
-// Package projectscope defines which project owns an organisation's resources
+package models
+
+import "go.mongodb.org/mongo-driver/bson/primitive"
+
+// The two helpers below define which project owns an organisation's resources
 // during the hidden single-project rollout.
 //
 // The rollout has no project UI, no switcher, and no API surface, so there is
@@ -17,10 +21,10 @@
 // A pure function cannot diverge. It performs no I/O, so it returns the same
 // value on every instance regardless of deployment order or collection state,
 // and it produces exactly the value the project materialisation will persist.
-// Callers must therefore never "improve" these helpers by adding a query.
-package projectscope
-
-import "go.mongodb.org/mongo-driver/bson/primitive"
+// Callers must therefore never "improve" these helpers by adding a query, and
+// they must stay free of any dependency that would make one possible — that is
+// why they live in this module rather than alongside the device ownership
+// resolution in the database module, which does query records.
 
 // DefaultProjectId returns the project that owns an organisation's resources
 // while no project has been explicitly assigned.

--- a/pkg/models/projectscope_test.go
+++ b/pkg/models/projectscope_test.go
@@ -1,4 +1,4 @@
-package projectscope
+package models
 
 import (
 	"testing"


### PR DESCRIPTION
## Description

This change folds the default project scope helpers into the `models` package so the ownership logic lives alongside the domain types it defines, instead of in a separate package with a very narrow purpose.

The motivation is to make the single-project rollout behavior easier to reason about and harder to misuse. These helpers are intentionally pure and deterministic: they must never depend on database state or runtime queries, otherwise different instances could derive different ownership values during rollout. Moving them into `models` reinforces that they are part of the domain model, not persistence logic.

The updated documentation also makes the architectural constraint explicit by clarifying why these helpers must remain isolated from any database dependencies. This improves maintainability by reducing package fragmentation while preserving the guarantees required for consistent project ownership resolution across deployments.