### PR TITLE
feat(project): add project CRUD contracts

### DIFF
--- a/pkg/api/project.go
+++ b/pkg/api/project.go
@@ -6,14 +6,21 @@ import "github.com/uug-ai/models/pkg/models"
 type ProjectStatus string
 
 const (
-	ProjectBindingFailed ProjectStatus = "project_binding_failed"
-	ProjectMissingInfo   ProjectStatus = "project_missing_info"
-	ProjectFound         ProjectStatus = "project_found"
-	ProjectNotFound      ProjectStatus = "project_not_found"
-	ProjectGetAllSuccess ProjectStatus = "project_get_all_success"
-	ProjectGetAllFailed  ProjectStatus = "project_get_all_failed"
-	ProjectUpdateSuccess ProjectStatus = "project_update_success"
-	ProjectUpdateFailed  ProjectStatus = "project_update_failed"
+	ProjectBindingFailed    ProjectStatus = "project_binding_failed"
+	ProjectMissingInfo      ProjectStatus = "project_missing_info"
+	ProjectFound            ProjectStatus = "project_found"
+	ProjectNotFound         ProjectStatus = "project_not_found"
+	ProjectForbidden        ProjectStatus = "project_forbidden"
+	ProjectNameExists       ProjectStatus = "project_name_exists"
+	ProjectDefaultImmutable ProjectStatus = "project_default_immutable"
+	ProjectGetAllSuccess    ProjectStatus = "project_get_all_success"
+	ProjectGetAllFailed     ProjectStatus = "project_get_all_failed"
+	ProjectCreateSuccess    ProjectStatus = "project_create_success"
+	ProjectCreateFailed     ProjectStatus = "project_create_failed"
+	ProjectUpdateSuccess    ProjectStatus = "project_update_success"
+	ProjectUpdateFailed     ProjectStatus = "project_update_failed"
+	ProjectDeleteSuccess    ProjectStatus = "project_delete_success"
+	ProjectDeleteFailed     ProjectStatus = "project_delete_failed"
 )
 
 // String returns the string representation of the project status.
@@ -26,14 +33,21 @@ func (s ProjectStatus) String() string {
 func (s ProjectStatus) Translate(lang string) string {
 	translations := map[string]map[ProjectStatus]string{
 		"en": {
-			ProjectBindingFailed: "Project binding failed",
-			ProjectMissingInfo:   "Project is missing required information",
-			ProjectFound:         "Project found",
-			ProjectNotFound:      "Project not found",
-			ProjectGetAllSuccess: "Projects retrieved successfully",
-			ProjectGetAllFailed:  "Failed to retrieve projects",
-			ProjectUpdateSuccess: "Project updated successfully",
-			ProjectUpdateFailed:  "Failed to update project",
+			ProjectBindingFailed:    "Project binding failed",
+			ProjectMissingInfo:      "Project is missing required information",
+			ProjectFound:            "Project found",
+			ProjectNotFound:         "Project not found",
+			ProjectForbidden:        "You do not have permission for this action",
+			ProjectNameExists:       "Project slug already exists",
+			ProjectDefaultImmutable: "The default project cannot be renamed or deleted",
+			ProjectGetAllSuccess:    "Projects retrieved successfully",
+			ProjectGetAllFailed:     "Failed to retrieve projects",
+			ProjectCreateSuccess:    "Project created successfully",
+			ProjectCreateFailed:     "Failed to create project",
+			ProjectUpdateSuccess:    "Project updated successfully",
+			ProjectUpdateFailed:     "Failed to update project",
+			ProjectDeleteSuccess:    "Project deleted successfully",
+			ProjectDeleteFailed:     "Failed to delete project",
 		},
 	}
 
@@ -60,6 +74,7 @@ func (s ProjectStatus) Translate(lang string) string {
 // caller is scoped organisation-wide.
 
 // GetProjects lists the projects in the caller's active organisation.
+// Soft-deleted projects are omitted unless ?includeInactive=true is supplied.
 // @Router /projects [get]
 type GetProjectsResponse struct {
 	Projects []models.Project `json:"projects"`
@@ -72,8 +87,8 @@ type GetProjectsErrorResponse struct {
 	ErrorResponse
 }
 
-// GetProject resolves a single project, currently the caller's active one
-// (/projects/current).
+// GetProject resolves a single project, either the caller's active one
+// (/projects/current) or one addressed by id (/projects/{id}).
 type GetProjectResponse struct {
 	Project models.Project `json:"project"`
 }
@@ -98,5 +113,55 @@ type SetCurrentProjectSuccessResponse struct {
 	Data SetCurrentProjectResponse `json:"data"`
 }
 type SetCurrentProjectErrorResponse struct {
+	ErrorResponse
+}
+
+// CreateProject creates a project inside the caller's active organisation. The
+// organisation, id and audit stamps on the supplied project are ignored and
+// filled in server-side; name and slug are required.
+// @Router /projects [post]
+type CreateProjectRequest struct {
+	Project models.Project `json:"project"`
+}
+type CreateProjectResponse struct {
+	Project models.Project `json:"project"`
+}
+type CreateProjectSuccessResponse struct {
+	SuccessResponse
+	Data CreateProjectResponse `json:"data"`
+}
+type CreateProjectErrorResponse struct {
+	ErrorResponse
+}
+
+// UpdateProject applies a partial update. The body is a ProjectUpdate patch:
+// only the fields present are changed (each field is optional).
+// @Router /projects/{id} [patch]
+type UpdateProjectRequest struct {
+	Project models.ProjectUpdate `json:"project"`
+}
+type UpdateProjectResponse struct {
+	Project models.Project `json:"project"`
+}
+type UpdateProjectSuccessResponse struct {
+	SuccessResponse
+	Data UpdateProjectResponse `json:"data"`
+}
+type UpdateProjectErrorResponse struct {
+	ErrorResponse
+}
+
+// DeleteProject soft-deletes a project. The returned project is the stored
+// document with its IsActive flag cleared; the organisation's default project
+// cannot be deleted.
+// @Router /projects/{id} [delete]
+type DeleteProjectResponse struct {
+	Project models.Project `json:"project"`
+}
+type DeleteProjectSuccessResponse struct {
+	SuccessResponse
+	Data DeleteProjectResponse `json:"data"`
+}
+type DeleteProjectErrorResponse struct {
 	ErrorResponse
 }

--- a/pkg/models/project.go
+++ b/pkg/models/project.go
@@ -21,12 +21,25 @@ type Project struct {
 const DefaultProjectSlug = "default"
 
 // GetProjectsInput lists the projects in the caller's active organisation.
+// Soft-deleted (inactive) projects are omitted unless IncludeInactive is set.
 type GetProjectsInput struct {
-	User User `json:"user"`
+	User            User `json:"user"`
+	IncludeInactive bool `json:"includeInactive"`
 }
 
 type GetProjectsOutput struct {
 	Projects []Project `json:"projects"`
+}
+
+// GetProjectInput resolves a single project by id within the caller's active
+// organisation.
+type GetProjectInput struct {
+	User      User   `json:"user"`
+	ProjectId string `json:"projectId"`
+}
+
+type GetProjectOutput struct {
+	Project *Project `json:"project"`
 }
 
 // GetCurrentProjectInput resolves the caller's active project (the one whose id
@@ -47,5 +60,54 @@ type SetCurrentProjectInput struct {
 }
 
 type SetCurrentProjectOutput struct {
+	Project *Project `json:"project"`
+}
+
+// CreateProjectInput creates a project inside the caller's active organisation.
+// Ownership, identity and audit stamps are server-managed and ignored on the
+// supplied Project.
+type CreateProjectInput struct {
+	User    User    `json:"user"`
+	Project Project `json:"project"`
+}
+
+type CreateProjectOutput struct {
+	Project *Project `json:"project"`
+}
+
+// ProjectUpdate is a partial-update (PATCH) payload for a project. Every field
+// is a pointer so a nil value means "not provided" (leave the stored value
+// untouched), which is distinct from an explicit zero value (e.g. clearing the
+// description or setting IsActive to false). Identity, ownership and audit
+// fields are intentionally absent because they are managed server-side.
+type ProjectUpdate struct {
+	Name        *string `json:"name,omitempty"`
+	Slug        *string `json:"slug,omitempty"`
+	Description *string `json:"description,omitempty"`
+	IsActive    *bool   `json:"isActive,omitempty"`
+}
+
+// UpdateProjectInput applies a partial update to a project in the caller's
+// active organisation. Only the fields set on the ProjectUpdate payload are
+// changed.
+type UpdateProjectInput struct {
+	User      User          `json:"user"`
+	ProjectId string        `json:"projectId"`
+	Project   ProjectUpdate `json:"project"`
+}
+
+type UpdateProjectOutput struct {
+	Project *Project `json:"project"`
+}
+
+// DeleteProjectInput soft-deletes a project: the document is retained and its
+// IsActive flag is cleared, so resources that still carry its id keep a
+// resolvable owner. The organisation's default project cannot be deleted.
+type DeleteProjectInput struct {
+	User      User   `json:"user"`
+	ProjectId string `json:"projectId"`
+}
+
+type DeleteProjectOutput struct {
 	Project *Project `json:"project"`
 }


### PR DESCRIPTION
## Description

Introduces the full set of project CRUD API contracts and model definitions, establishing a complete and consistent foundation for project lifecycle management across services.

The change expands the existing project API beyond retrieval and current-project selection by adding:
- Create, update, and delete request/response contracts
- Dedicated input/output model types for each operation
- Partial update support through `ProjectUpdate` patch semantics
- Soft-delete support with optional inclusion of inactive projects
- Project-specific validation and permission statuses
- Explicit protections for immutable default projects

These additions improve the project by standardizing how services interact with project resources and by making the API behavior more explicit and extensible. The new contracts clearly separate server-managed fields from client-controlled data, reduce ambiguity around updates, and support safer deletion semantics through soft deletes instead of hard removal.

The added status codes and translations also improve API ergonomics by enabling clearer error handling for common edge cases such as duplicate slugs, forbidden actions, and immutable default projects. Overall, this creates a more complete, predictable, and maintainable contract layer for future project management features.