### PR TITLE
Feat/project slug rules

### DIFF
--- a/pkg/models/organisationslug.go
+++ b/pkg/models/organisationslug.go
@@ -1,0 +1,138 @@
+package models
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrOrganisationSlugInvalid is returned when an organisation slug is not in
+// canonical form, or when it is reserved by the platform.
+var ErrOrganisationSlugInvalid = errors.New("organisation slug is not well formed")
+
+// MaxOrganisationSlugLength is the longest an organisation slug may be. See
+// maxSlugLength.
+const MaxOrganisationSlugLength = maxSlugLength
+
+// reservedOrganisationSlugs are the organisation slugs no caller may claim.
+//
+// This list is longer than reservedProjectSlugs, and deliberately so. An
+// organisation slug is unique *globally* — the index is a single-key unique
+// partial index on {slug: 1}, not the compound {organisationId, slug} the
+// project collection uses — and it is the outermost path segment, so it is the
+// one that would collide with the platform's own top-level routes. A word
+// claimed here is claimed for every tenant at once, which makes both the
+// routing collisions and the squatting worth guarding against up front.
+//
+// Reserving is close to one-way: removing a word later is free, adding one
+// later can invalidate slugs already stored and referenced. No organisation in
+// production holds a slug yet, so the cost of being generous is zero today and
+// only rises from here.
+var reservedOrganisationSlugs = map[string]struct{}{
+	// Words that read as "no organisation" or "every organisation". An
+	// organisation whose slug is a sentinel invites code that treats it as one.
+	"default": {}, "none": {}, "null": {}, "nil": {}, "undefined": {},
+	"all": {}, "any": {}, "unassigned": {}, "unknown": {},
+
+	// Platform surfaces and infrastructure hostnames. These are the segments a
+	// /<orgSlug>/... scheme collides with directly.
+	"api": {}, "admin": {}, "app": {}, "assets": {}, "static": {}, "public": {},
+	"internal": {}, "system": {}, "health": {}, "healthz": {}, "readyz": {},
+	"status": {}, "metrics": {}, "well-known": {}, "www": {}, "mail": {},
+	"smtp": {}, "ftp": {}, "cdn": {}, "ns": {}, "mx": {}, "localhost": {},
+	"graphql": {}, "grpc": {}, "ws": {}, "websocket": {}, "webhook": {},
+	"webhooks": {}, "sitemap": {}, "robots": {}, "favicon": {},
+
+	// Authentication and account lifecycle routes.
+	"login": {}, "logout": {}, "signin": {}, "signout": {}, "signup": {},
+	"register": {}, "auth": {}, "oauth": {}, "sso": {}, "saml": {}, "callback": {},
+	"token": {}, "session": {}, "password": {}, "forgot": {}, "reset": {},
+	"verify": {}, "confirm": {}, "activate": {}, "invite": {}, "invites": {},
+	"invitation": {}, "invitations": {}, "mfa": {}, "2fa": {},
+
+	// Resource collection names, which are what a reader most easily mistakes an
+	// organisation slug for.
+	"organisation": {}, "organisations": {}, "organization": {},
+	"organizations": {}, "org": {}, "orgs": {}, "project": {}, "projects": {},
+	"user": {}, "users": {}, "account": {}, "accounts": {}, "team": {},
+	"teams": {}, "member": {}, "members": {}, "role": {}, "roles": {},
+	"permission": {}, "permissions": {}, "group": {}, "groups": {},
+	"device": {}, "devices": {}, "media": {}, "site": {}, "sites": {},
+
+	// Generic action and navigation segments.
+	"new": {}, "create": {}, "edit": {}, "update": {}, "delete": {},
+	"search": {}, "settings": {}, "config": {}, "dashboard": {}, "home": {},
+	"index": {}, "me": {}, "my": {}, "self": {}, "profile": {},
+
+	// Commercial and legal surfaces, which tend to become top-level routes on
+	// the marketing side of the same hostname.
+	"billing": {}, "invoice": {}, "invoices": {}, "subscription": {},
+	"subscriptions": {}, "plan": {}, "plans": {}, "pricing": {}, "checkout": {},
+	"legal": {}, "privacy": {}, "terms": {}, "security": {}, "abuse": {},
+	"support": {}, "help": {}, "docs": {}, "documentation": {}, "blog": {},
+	"about": {}, "contact": {}, "careers": {},
+
+	// Environment names, which are the words most likely to be typed into a
+	// tenant-creation form during a test and then never cleaned up.
+	"test": {}, "demo": {}, "example": {}, "sandbox": {}, "staging": {},
+	"production": {}, "dev": {}, "development": {}, "preview": {},
+
+	// Product and company names, held back from first-come-first-served because
+	// the namespace is global.
+	"kerberos": {}, "kerberosio": {}, "uug": {}, "uugai": {}, "hub": {},
+}
+
+// IsReservedOrganisationSlug reports whether slug is reserved by the platform.
+//
+// The argument is case-sensitive and assumes canonical form; ValidateOrganisationSlug
+// runs the format check first for exactly that reason. Prefer that function —
+// this one is exported for callers that need to explain *why* a slug was
+// refused, or to surface the distinction in documentation.
+func IsReservedOrganisationSlug(slug string) bool {
+	_, reserved := reservedOrganisationSlugs[slug]
+	return reserved
+}
+
+// ReservedOrganisationSlugs returns the reserved organisation slugs in sorted
+// order. It returns a fresh slice on every call so a caller cannot mutate the
+// set.
+func ReservedOrganisationSlugs() []string {
+	return sortedSlugs(reservedOrganisationSlugs)
+}
+
+// ValidateOrganisationSlugFormat reports whether slug is in canonical form. It
+// does not consider whether the slug is reserved; see IsReservedOrganisationSlug.
+//
+// Most callers want ValidateOrganisationSlug instead. This exists for the same
+// reason its project counterpart does: to keep the shape check available on its
+// own, so a caller that has already established a slug's provenance is not
+// forced to re-apply the reserved list to it.
+func ValidateOrganisationSlugFormat(slug string) error {
+	return validateSlugFormat(slug, ErrOrganisationSlugInvalid)
+}
+
+// ValidateOrganisationSlug reports whether slug may be written to an
+// organisation. It combines the format and reserved checks, which the project
+// equivalent deliberately keeps apart.
+//
+// The asymmetry is not an inconsistency. DefaultProjectSlug is reserved *and*
+// held by a real document that the server mints itself, so folding the checks
+// together there would reject the one write meant to succeed. Nothing mints an
+// organisation slug — the bootstrap tool is forbidden from synthesizing one, and
+// the field is optional precisely so it can stay absent — so for organisations
+// every write is caller-supplied and both checks always apply.
+//
+// The slug is optional: an organisation with no slug is valid, and its absence
+// is what the partial unique index is built around. Callers must therefore test
+// for an absent slug before calling this, rather than passing "" and expecting
+// it to pass. Writing "" is not the same as writing nothing: the index treats
+// the empty string as a value, so the second organisation to store one would
+// collide with the first, globally.
+func ValidateOrganisationSlug(slug string) error {
+	if err := ValidateOrganisationSlugFormat(slug); err != nil {
+		return err
+	}
+	if IsReservedOrganisationSlug(slug) {
+		return fmt.Errorf("%w: slug is reserved by the platform", ErrOrganisationSlugInvalid)
+	}
+	return nil
+}

--- a/pkg/models/organisationslug_test.go
+++ b/pkg/models/organisationslug_test.go
@@ -1,0 +1,183 @@
+package models
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// TestValidateOrganisationSlugAcceptsCanonicalForms pins the shapes a caller is
+// allowed to keep.
+func TestValidateOrganisationSlugAcceptsCanonicalForms(t *testing.T) {
+	for _, slug := range []string{
+		"a",
+		"7",
+		"acme-corp",
+		"acme-2",
+		"a-b-c-d",
+		strings.Repeat("a", MaxOrganisationSlugLength),
+	} {
+		t.Run(slug, func(t *testing.T) {
+			if err := ValidateOrganisationSlug(slug); err != nil {
+				t.Fatalf("validate %q = %v, want nil", slug, err)
+			}
+		})
+	}
+}
+
+// TestValidateOrganisationSlugRejectsNonCanonicalForms documents every rule. The
+// uppercase cases matter most: the global unique index compares bytes, so
+// without this check "Admin" would clear the reserved list and still occupy a
+// name no other tenant could take in canonical form.
+func TestValidateOrganisationSlugRejectsNonCanonicalForms(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		slug string
+	}{
+		{name: "empty", slug: ""},
+		{name: "whitespace only", slug: "   "},
+		{name: "inner space", slug: "acme corp"},
+		{name: "leading space", slug: " acme-corp"},
+		{name: "trailing space", slug: "acme-corp "},
+		{name: "uppercase", slug: "Acme-Corp"},
+		{name: "reserved slug in another case", slug: "Admin"},
+		{name: "reserved slug shouting", slug: "API"},
+		{name: "underscore", slug: "acme_corp"},
+		{name: "path traversal", slug: "../etc"},
+		{name: "slash", slug: "acme/corp"},
+		{name: "percent encoded", slug: "acme%20corp"},
+		{name: "leading hyphen", slug: "-acme"},
+		{name: "trailing hyphen", slug: "acme-"},
+		{name: "consecutive hyphens", slug: "acme--corp"},
+		{name: "too long", slug: strings.Repeat("a", MaxOrganisationSlugLength+1)},
+		{name: "object id shaped", slug: "507f1f77bcf86cd799439011"},
+		{name: "non ascii", slug: "äcme"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateOrganisationSlug(tc.slug)
+			if !errors.Is(err, ErrOrganisationSlugInvalid) {
+				t.Fatalf("validate %q = %v, want ErrOrganisationSlugInvalid", tc.slug, err)
+			}
+			if tc.slug != "" && strings.Contains(err.Error(), tc.slug) {
+				t.Fatalf("error message echoes the supplied value: %v", err)
+			}
+		})
+	}
+}
+
+// TestValidateOrganisationSlugRejectsEveryReservedSlug walks the whole set
+// rather than sampling it, so a word added to the list without being reachable
+// through the validator is caught here rather than in production.
+func TestValidateOrganisationSlugRejectsEveryReservedSlug(t *testing.T) {
+	reserved := ReservedOrganisationSlugs()
+	if len(reserved) == 0 {
+		t.Fatal("reserved slugs = 0, want a non-empty set")
+	}
+
+	for _, slug := range reserved {
+		if err := ValidateOrganisationSlug(slug); !errors.Is(err, ErrOrganisationSlugInvalid) {
+			t.Errorf("validate reserved %q = %v, want ErrOrganisationSlugInvalid", slug, err)
+		}
+	}
+}
+
+// TestReservedOrganisationSlugsAreThemselvesCanonical keeps the list reachable.
+// A reserved word that fails format validation is dead weight: no caller could
+// ever submit it, so reserving it protects nothing and misleads whoever reads
+// the list.
+func TestReservedOrganisationSlugsAreThemselvesCanonical(t *testing.T) {
+	for _, slug := range ReservedOrganisationSlugs() {
+		if err := ValidateOrganisationSlugFormat(slug); err != nil {
+			t.Errorf("reserved slug %q is not itself a valid slug: %v", slug, err)
+		}
+	}
+}
+
+// TestValidateOrganisationSlugFormatIgnoresTheReservedSet separates the two
+// checks. The format function is exported on its own, so it has to stay a pure
+// shape check even though the combined validator is what callers normally use.
+func TestValidateOrganisationSlugFormatIgnoresTheReservedSet(t *testing.T) {
+	for _, slug := range ReservedOrganisationSlugs() {
+		if err := ValidateOrganisationSlugFormat(slug); err != nil {
+			t.Fatalf("format check rejected reserved slug %q: %v", slug, err)
+		}
+	}
+}
+
+// TestIsReservedOrganisationSlugIsCaseSensitive documents the contract callers
+// rely on: this check assumes canonical input and is not a substitute for
+// format validation.
+func TestIsReservedOrganisationSlugIsCaseSensitive(t *testing.T) {
+	for _, slug := range []string{"Admin", "ADMIN", "Api", "acme-corp", ""} {
+		if IsReservedOrganisationSlug(slug) {
+			t.Errorf("IsReservedOrganisationSlug(%q) = true, want false", slug)
+		}
+	}
+}
+
+// TestReservedOrganisationSlugsReturnsAnIsolatedCopy stops a caller mutating the
+// set through the accessor.
+func TestReservedOrganisationSlugsReturnsAnIsolatedCopy(t *testing.T) {
+	first := ReservedOrganisationSlugs()
+	if len(first) == 0 {
+		t.Fatal("reserved slugs = 0, want a non-empty set")
+	}
+	first[0] = "mutated"
+
+	for _, slug := range ReservedOrganisationSlugs() {
+		if slug == "mutated" {
+			t.Fatal("mutating the returned slice changed the reserved set")
+		}
+	}
+}
+
+// TestOrganisationAndProjectSlugSetsAreIndependent pins the decision to keep two
+// literal lists instead of deriving one from the other. The organisation slug is
+// globally unique and sits in the outer path segment, so it reserves words the
+// project slug has no reason to; this fails if someone collapses them into a
+// shared base and quietly widens the project set.
+func TestOrganisationAndProjectSlugSetsAreIndependent(t *testing.T) {
+	project := map[string]struct{}{}
+	for _, slug := range ReservedProjectSlugs() {
+		project[slug] = struct{}{}
+	}
+
+	var onlyOrganisation int
+	for _, slug := range ReservedOrganisationSlugs() {
+		if _, shared := project[slug]; !shared {
+			onlyOrganisation++
+		}
+	}
+	if onlyOrganisation == 0 {
+		t.Fatal("no organisation-only reserved slugs, want the sets to differ")
+	}
+
+	// The default project slug is reserved for projects because a real document
+	// holds it. Nothing holds it for organisations, but an organisation called
+	// "default" reads as "no organisation" everywhere the project sentinel reads
+	// as "no project", so it is reserved on both sides for different reasons.
+	if !IsReservedOrganisationSlug(DefaultProjectSlug) {
+		t.Errorf("IsReservedOrganisationSlug(%q) = false, want true", DefaultProjectSlug)
+	}
+}
+
+// TestOrganisationAndProjectSlugFormatsAgree pins the shared shape engine: the
+// reserved sets are allowed to diverge, the shape rules are not. A caller should
+// never have to remember which slug kind tolerates an underscore.
+func TestOrganisationAndProjectSlugFormatsAgree(t *testing.T) {
+	for _, slug := range []string{
+		"a", "acme-corp", "site-2", "Acme", "acme_corp", "acme--corp",
+		"-acme", "acme-", "", "   ", "../etc", "507f1f77bcf86cd799439011",
+		strings.Repeat("a", maxSlugLength),
+		strings.Repeat("a", maxSlugLength+1),
+	} {
+		t.Run(slug, func(t *testing.T) {
+			organisation := ValidateOrganisationSlugFormat(slug) != nil
+			project := ValidateProjectSlugFormat(slug) != nil
+			if organisation != project {
+				t.Fatalf("format checks disagree on %q: organisation rejected = %v, project rejected = %v",
+					slug, organisation, project)
+			}
+		})
+	}
+}

--- a/pkg/models/projectslug.go
+++ b/pkg/models/projectslug.go
@@ -2,28 +2,25 @@ package models
 
 import (
 	"errors"
-	"fmt"
-	"sort"
 )
 
-// ErrProjectSlugInvalid is returned when a slug is not in canonical form.
+// ErrProjectSlugInvalid is returned when a project slug is not in canonical form.
 var ErrProjectSlugInvalid = errors.New("project slug is not well formed")
 
-const (
-	// MaxProjectSlugLength follows the DNS label limit. A slug is intended to be
-	// usable as a URL path segment, so bounding it here keeps that option open.
-	MaxProjectSlugLength = 63
+// MaxProjectSlugLength is the longest a project slug may be. See maxSlugLength.
+const MaxProjectSlugLength = maxSlugLength
 
-	// objectIDHexLength is the width of a hex-encoded ObjectID.
-	objectIDHexLength = 24
-)
-
-// reservedProjectSlugs are the slugs no caller may claim.
+// reservedProjectSlugs are the project slugs no caller may claim.
 //
 // Reserving is close to one-way. Removing a word later is free, but adding one
 // later can invalidate slugs that are already stored and already referenced, so
 // the list errs towards generous now while the project collection is still
 // effectively empty.
+//
+// This set is deliberately kept separate from reservedOrganisationSlugs rather
+// than derived from it. The two slugs occupy different path positions, so a word
+// added to one for a routing reason is usually irrelevant to the other; a shared
+// base would make every such addition a change to both.
 //
 // The groups below are the reasons a word is here; they are not a taxonomy
 // anyone needs to preserve when editing the list.
@@ -62,7 +59,9 @@ var reservedProjectSlugs = map[string]struct{}{
 // by exactly one document per organisation, the server-minted default — so a
 // single function returning "invalid" for it would reject the one write that is
 // supposed to succeed. Callers validate the format for every slug, and consult
-// this only for caller-supplied ones.
+// this only for caller-supplied ones. The organisation slug has no such
+// server-minted holder, which is why ValidateOrganisationSlug can combine the
+// two checks and this one cannot.
 //
 // The argument is case-sensitive and assumes canonical form. Pass it through
 // ValidateProjectSlugFormat first: without that, "Default" misses this check,
@@ -73,16 +72,11 @@ func IsReservedProjectSlug(slug string) bool {
 	return reserved
 }
 
-// ReservedProjectSlugs returns the reserved slugs in sorted order. It returns a
-// fresh slice on every call so a caller cannot mutate the set. Intended for
-// surfacing the list in API documentation and error responses.
+// ReservedProjectSlugs returns the reserved project slugs in sorted order. It
+// returns a fresh slice on every call so a caller cannot mutate the set.
+// Intended for surfacing the list in API documentation and error responses.
 func ReservedProjectSlugs() []string {
-	slugs := make([]string, 0, len(reservedProjectSlugs))
-	for slug := range reservedProjectSlugs {
-		slugs = append(slugs, slug)
-	}
-	sort.Strings(slugs)
-	return slugs
+	return sortedSlugs(reservedProjectSlugs)
 }
 
 // ValidateProjectSlugFormat reports whether slug is in canonical form. It does
@@ -93,64 +87,6 @@ func ReservedProjectSlugs() []string {
 // than no rule. One service accepting what another rejects means a slug that is
 // writable but unroutable, or a reserved word that is unforgeable in one
 // service and forgeable in the next.
-//
-// The rules are deliberately narrow, because a slug is the one project
-// identifier meant to be stable and human-visible: once it is written and
-// referenced, tightening the rules means rewriting stored values and breaking
-// whatever pointed at them.
-//
-//   - lowercase letters, digits and "-" only, so a slug is unambiguous in a URL
-//     and comparisons need no case folding or collation.
-//   - no leading, trailing or repeated "-", so one logical name has one spelling.
-//   - not shaped like an ObjectID, so a route carrying both a slug and an id can
-//     tell them apart without guessing.
-//
-// Error messages describe the rule that failed and never echo the supplied
-// value, which keeps caller input out of logs and responses.
 func ValidateProjectSlugFormat(slug string) error {
-	if slug == "" {
-		return fmt.Errorf("%w: slug is empty", ErrProjectSlugInvalid)
-	}
-	if len(slug) > MaxProjectSlugLength {
-		return fmt.Errorf("%w: slug is longer than %d characters", ErrProjectSlugInvalid, MaxProjectSlugLength)
-	}
-
-	for i := 0; i < len(slug); i++ {
-		c := slug[i]
-		switch {
-		case c >= 'a' && c <= 'z', c >= '0' && c <= '9':
-		case c == '-':
-			if i == 0 || i == len(slug)-1 {
-				return fmt.Errorf("%w: slug may not start or end with a hyphen", ErrProjectSlugInvalid)
-			}
-			if slug[i-1] == '-' {
-				return fmt.Errorf("%w: slug may not contain consecutive hyphens", ErrProjectSlugInvalid)
-			}
-		default:
-			return fmt.Errorf("%w: slug may only contain lowercase letters, digits and hyphens", ErrProjectSlugInvalid)
-		}
-	}
-
-	if isObjectIDShapedSlug(slug) {
-		return fmt.Errorf("%w: slug may not be shaped like an object id", ErrProjectSlugInvalid)
-	}
-
-	return nil
-}
-
-// isObjectIDShapedSlug reports whether slug could be read as a hex-encoded
-// ObjectID. Only the lowercase form is checked because ValidateProjectSlugFormat
-// has already rejected uppercase by the time this runs.
-func isObjectIDShapedSlug(slug string) bool {
-	if len(slug) != objectIDHexLength {
-		return false
-	}
-	for i := 0; i < len(slug); i++ {
-		c := slug[i]
-		if (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') {
-			continue
-		}
-		return false
-	}
-	return true
+	return validateSlugFormat(slug, ErrProjectSlugInvalid)
 }

--- a/pkg/models/projectslug.go
+++ b/pkg/models/projectslug.go
@@ -1,0 +1,156 @@
+package models
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+)
+
+// ErrProjectSlugInvalid is returned when a slug is not in canonical form.
+var ErrProjectSlugInvalid = errors.New("project slug is not well formed")
+
+const (
+	// MaxProjectSlugLength follows the DNS label limit. A slug is intended to be
+	// usable as a URL path segment, so bounding it here keeps that option open.
+	MaxProjectSlugLength = 63
+
+	// objectIDHexLength is the width of a hex-encoded ObjectID.
+	objectIDHexLength = 24
+)
+
+// reservedProjectSlugs are the slugs no caller may claim.
+//
+// Reserving is close to one-way. Removing a word later is free, but adding one
+// later can invalidate slugs that are already stored and already referenced, so
+// the list errs towards generous now while the project collection is still
+// effectively empty.
+//
+// The groups below are the reasons a word is here; they are not a taxonomy
+// anyone needs to preserve when editing the list.
+var reservedProjectSlugs = map[string]struct{}{
+	// The default project identity, plus the words that read as "no project" or
+	// "every project". A slug that looks like a sentinel invites code that
+	// special-cases it as one.
+	"default": {}, "none": {}, "null": {}, "nil": {}, "undefined": {},
+	"all": {}, "any": {}, "unassigned": {},
+
+	// Path segments a future /<orgSlug>/<projectSlug> scheme would collide with,
+	// or that name the platform's own surfaces.
+	"api": {}, "admin": {}, "app": {}, "assets": {}, "static": {}, "public": {},
+	"internal": {}, "system": {}, "health": {}, "healthz": {}, "status": {},
+	"metrics": {}, "well-known": {},
+
+	// Authentication routes.
+	"login": {}, "logout": {}, "signin": {}, "signout": {}, "signup": {},
+	"auth": {}, "oauth": {}, "callback": {}, "token": {}, "session": {},
+
+	// Resource collection names. These are the ones most likely to appear as a
+	// sibling segment of a project slug.
+	"organisation": {}, "organisations": {}, "org": {}, "orgs": {},
+	"project": {}, "projects": {}, "user": {}, "users": {},
+	"account": {}, "accounts": {},
+
+	// Generic action segments.
+	"new": {}, "create": {}, "edit": {}, "update": {}, "delete": {},
+	"search": {}, "settings": {}, "config": {},
+}
+
+// IsReservedProjectSlug reports whether slug is reserved by the platform.
+//
+// This is deliberately separate from ValidateProjectSlugFormat rather than
+// folded into it. DefaultProjectSlug is both reserved and legitimately held —
+// by exactly one document per organisation, the server-minted default — so a
+// single function returning "invalid" for it would reject the one write that is
+// supposed to succeed. Callers validate the format for every slug, and consult
+// this only for caller-supplied ones.
+//
+// The argument is case-sensitive and assumes canonical form. Pass it through
+// ValidateProjectSlugFormat first: without that, "Default" misses this check,
+// misses an exact comparison against DefaultProjectSlug, and misses a
+// byte-comparison unique index.
+func IsReservedProjectSlug(slug string) bool {
+	_, reserved := reservedProjectSlugs[slug]
+	return reserved
+}
+
+// ReservedProjectSlugs returns the reserved slugs in sorted order. It returns a
+// fresh slice on every call so a caller cannot mutate the set. Intended for
+// surfacing the list in API documentation and error responses.
+func ReservedProjectSlugs() []string {
+	slugs := make([]string, 0, len(reservedProjectSlugs))
+	for slug := range reservedProjectSlugs {
+		slugs = append(slugs, slug)
+	}
+	sort.Strings(slugs)
+	return slugs
+}
+
+// ValidateProjectSlugFormat reports whether slug is in canonical form. It does
+// not consider whether the slug is reserved; see IsReservedProjectSlug.
+//
+// The rules live here, next to DefaultProjectId and ResolveProjectId, for the
+// same reason those do: a slug rule that two services disagree about is worse
+// than no rule. One service accepting what another rejects means a slug that is
+// writable but unroutable, or a reserved word that is unforgeable in one
+// service and forgeable in the next.
+//
+// The rules are deliberately narrow, because a slug is the one project
+// identifier meant to be stable and human-visible: once it is written and
+// referenced, tightening the rules means rewriting stored values and breaking
+// whatever pointed at them.
+//
+//   - lowercase letters, digits and "-" only, so a slug is unambiguous in a URL
+//     and comparisons need no case folding or collation.
+//   - no leading, trailing or repeated "-", so one logical name has one spelling.
+//   - not shaped like an ObjectID, so a route carrying both a slug and an id can
+//     tell them apart without guessing.
+//
+// Error messages describe the rule that failed and never echo the supplied
+// value, which keeps caller input out of logs and responses.
+func ValidateProjectSlugFormat(slug string) error {
+	if slug == "" {
+		return fmt.Errorf("%w: slug is empty", ErrProjectSlugInvalid)
+	}
+	if len(slug) > MaxProjectSlugLength {
+		return fmt.Errorf("%w: slug is longer than %d characters", ErrProjectSlugInvalid, MaxProjectSlugLength)
+	}
+
+	for i := 0; i < len(slug); i++ {
+		c := slug[i]
+		switch {
+		case c >= 'a' && c <= 'z', c >= '0' && c <= '9':
+		case c == '-':
+			if i == 0 || i == len(slug)-1 {
+				return fmt.Errorf("%w: slug may not start or end with a hyphen", ErrProjectSlugInvalid)
+			}
+			if slug[i-1] == '-' {
+				return fmt.Errorf("%w: slug may not contain consecutive hyphens", ErrProjectSlugInvalid)
+			}
+		default:
+			return fmt.Errorf("%w: slug may only contain lowercase letters, digits and hyphens", ErrProjectSlugInvalid)
+		}
+	}
+
+	if isObjectIDShapedSlug(slug) {
+		return fmt.Errorf("%w: slug may not be shaped like an object id", ErrProjectSlugInvalid)
+	}
+
+	return nil
+}
+
+// isObjectIDShapedSlug reports whether slug could be read as a hex-encoded
+// ObjectID. Only the lowercase form is checked because ValidateProjectSlugFormat
+// has already rejected uppercase by the time this runs.
+func isObjectIDShapedSlug(slug string) bool {
+	if len(slug) != objectIDHexLength {
+		return false
+	}
+	for i := 0; i < len(slug); i++ {
+		c := slug[i]
+		if (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') {
+			continue
+		}
+		return false
+	}
+	return true
+}

--- a/pkg/models/projectslug_test.go
+++ b/pkg/models/projectslug_test.go
@@ -1,0 +1,138 @@
+package models
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// TestValidateProjectSlugFormatAcceptsCanonicalForms pins the shapes a caller is
+// allowed to keep, including the reserved default slug: the server mints that
+// document itself, so the constant has to survive format validation even though
+// IsReservedProjectSlug refuses it to callers.
+func TestValidateProjectSlugFormatAcceptsCanonicalForms(t *testing.T) {
+	for _, slug := range []string{
+		"a",
+		"7",
+		"warehouse-north",
+		"site-2",
+		"a-b-c-d",
+		DefaultProjectSlug,
+		strings.Repeat("a", MaxProjectSlugLength),
+	} {
+		t.Run(slug, func(t *testing.T) {
+			if err := ValidateProjectSlugFormat(slug); err != nil {
+				t.Fatalf("validate %q = %v, want nil", slug, err)
+			}
+		})
+	}
+}
+
+// TestValidateProjectSlugFormatRejectsNonCanonicalForms documents every rule.
+// The uppercase cases matter most: they are what makes a reserved slug
+// unforgeable, since IsReservedProjectSlug and the unique {organisationId, slug}
+// index both compare bytes.
+func TestValidateProjectSlugFormatRejectsNonCanonicalForms(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		slug string
+	}{
+		{name: "empty", slug: ""},
+		{name: "whitespace only", slug: "   "},
+		{name: "inner space", slug: "warehouse north"},
+		{name: "leading space", slug: " warehouse-north"},
+		{name: "trailing space", slug: "warehouse-north "},
+		{name: "uppercase", slug: "Warehouse-North"},
+		{name: "reserved slug in another case", slug: "Default"},
+		{name: "reserved slug shouting", slug: "DEFAULT"},
+		{name: "underscore", slug: "warehouse_north"},
+		{name: "path traversal", slug: "../etc"},
+		{name: "slash", slug: "warehouse/north"},
+		{name: "percent encoded", slug: "warehouse%20north"},
+		{name: "leading hyphen", slug: "-warehouse"},
+		{name: "trailing hyphen", slug: "warehouse-"},
+		{name: "consecutive hyphens", slug: "warehouse--north"},
+		{name: "too long", slug: strings.Repeat("a", MaxProjectSlugLength+1)},
+		{name: "object id shaped", slug: "507f1f77bcf86cd799439011"},
+		{name: "non ascii", slug: "wärehouse"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateProjectSlugFormat(tc.slug)
+			if !errors.Is(err, ErrProjectSlugInvalid) {
+				t.Fatalf("validate %q = %v, want ErrProjectSlugInvalid", tc.slug, err)
+			}
+			if tc.slug != "" && strings.Contains(err.Error(), tc.slug) {
+				t.Fatalf("error message echoes the supplied value: %v", err)
+			}
+		})
+	}
+}
+
+// TestValidateProjectSlugFormatRejectsIdShapedSlugsOnly guards the narrowness of
+// the object-id rule: it must reject a 24-character hex string without rejecting
+// every string that happens to be 24 characters long.
+func TestValidateProjectSlugFormatRejectsIdShapedSlugsOnly(t *testing.T) {
+	idShaped := "507f1f77bcf86cd799439011"
+	if len(idShaped) != objectIDHexLength {
+		t.Fatalf("fixture length = %d, want %d", len(idShaped), objectIDHexLength)
+	}
+	if err := ValidateProjectSlugFormat(idShaped); !errors.Is(err, ErrProjectSlugInvalid) {
+		t.Fatalf("validate %q = %v, want ErrProjectSlugInvalid", idShaped, err)
+	}
+
+	// Same length, but the trailing "z" puts it outside the hex alphabet.
+	sameLength := "507f1f77bcf86cd79943901z"
+	if len(sameLength) != objectIDHexLength {
+		t.Fatalf("fixture length = %d, want %d", len(sameLength), objectIDHexLength)
+	}
+	if err := ValidateProjectSlugFormat(sameLength); err != nil {
+		t.Fatalf("validate %q = %v, want nil", sameLength, err)
+	}
+}
+
+// TestReservedProjectSlugsAreThemselvesCanonical keeps the list reachable. A
+// reserved word that fails format validation is dead weight: no caller could
+// ever submit it, so reserving it protects nothing and misleads whoever reads
+// the list.
+func TestReservedProjectSlugsAreThemselvesCanonical(t *testing.T) {
+	for _, slug := range ReservedProjectSlugs() {
+		if err := ValidateProjectSlugFormat(slug); err != nil {
+			t.Errorf("reserved slug %q is not itself a valid slug: %v", slug, err)
+		}
+	}
+}
+
+// TestDefaultProjectSlugIsReserved ties the constant to the list. The default
+// project identity is only unforgeable while no caller can claim its slug.
+func TestDefaultProjectSlugIsReserved(t *testing.T) {
+	if !IsReservedProjectSlug(DefaultProjectSlug) {
+		t.Fatalf("IsReservedProjectSlug(%q) = false, want true", DefaultProjectSlug)
+	}
+}
+
+// TestIsReservedProjectSlugIsCaseSensitive documents the contract callers rely
+// on: this check assumes canonical input and is not a substitute for format
+// validation.
+func TestIsReservedProjectSlugIsCaseSensitive(t *testing.T) {
+	for _, slug := range []string{"Default", "DEFAULT", "Admin", "warehouse-north", ""} {
+		if IsReservedProjectSlug(slug) {
+			t.Errorf("IsReservedProjectSlug(%q) = true, want false", slug)
+		}
+	}
+}
+
+// TestReservedProjectSlugsReturnsAnIsolatedCopy stops a caller mutating the set
+// through the accessor.
+func TestReservedProjectSlugsReturnsAnIsolatedCopy(t *testing.T) {
+	first := ReservedProjectSlugs()
+	if len(first) == 0 {
+		t.Fatal("reserved slugs = 0, want a non-empty set")
+	}
+	first[0] = "mutated"
+
+	for _, slug := range ReservedProjectSlugs() {
+		if slug == "mutated" {
+			t.Fatal("mutating the returned slice changed the reserved set")
+		}
+	}
+}

--- a/pkg/models/slug.go
+++ b/pkg/models/slug.go
@@ -1,0 +1,92 @@
+package models
+
+import (
+	"fmt"
+	"sort"
+)
+
+// maxSlugLength follows the DNS label limit. A slug is intended to be usable as
+// a URL path segment, so bounding it here keeps that option open.
+const maxSlugLength = 63
+
+// objectIDHexLength is the width of a hex-encoded ObjectID.
+const objectIDHexLength = 24
+
+// validateSlugFormat reports whether slug is in canonical form, wrapping the
+// caller's sentinel so each slug kind keeps its own errors.Is target.
+//
+// The organisation slug and the project slug sit at different points of a URL
+// and reserve different words, but they are the same kind of identifier and a
+// caller should never have to remember which one tolerates an underscore. The
+// shape rules are therefore shared verbatim; only the reserved sets differ.
+//
+// The rules are deliberately narrow, because a slug is the one identifier meant
+// to be stable and human-visible: once it is written and referenced, tightening
+// the rules means rewriting stored values and breaking whatever pointed at them.
+//
+//   - lowercase letters, digits and "-" only, so a slug is unambiguous in a URL
+//     and comparisons need no case folding or collation.
+//   - no leading, trailing or repeated "-", so one logical name has one spelling.
+//   - not shaped like an ObjectID, so a route carrying both a slug and an id can
+//     tell them apart without guessing.
+//
+// Error messages describe the rule that failed and never echo the supplied
+// value, which keeps caller input out of logs and responses.
+func validateSlugFormat(slug string, sentinel error) error {
+	if slug == "" {
+		return fmt.Errorf("%w: slug is empty", sentinel)
+	}
+	if len(slug) > maxSlugLength {
+		return fmt.Errorf("%w: slug is longer than %d characters", sentinel, maxSlugLength)
+	}
+
+	for i := 0; i < len(slug); i++ {
+		c := slug[i]
+		switch {
+		case c >= 'a' && c <= 'z', c >= '0' && c <= '9':
+		case c == '-':
+			if i == 0 || i == len(slug)-1 {
+				return fmt.Errorf("%w: slug may not start or end with a hyphen", sentinel)
+			}
+			if slug[i-1] == '-' {
+				return fmt.Errorf("%w: slug may not contain consecutive hyphens", sentinel)
+			}
+		default:
+			return fmt.Errorf("%w: slug may only contain lowercase letters, digits and hyphens", sentinel)
+		}
+	}
+
+	if isObjectIDShapedSlug(slug) {
+		return fmt.Errorf("%w: slug may not be shaped like an object id", sentinel)
+	}
+
+	return nil
+}
+
+// isObjectIDShapedSlug reports whether slug could be read as a hex-encoded
+// ObjectID. Only the lowercase form is checked because validateSlugFormat has
+// already rejected uppercase by the time this runs.
+func isObjectIDShapedSlug(slug string) bool {
+	if len(slug) != objectIDHexLength {
+		return false
+	}
+	for i := 0; i < len(slug); i++ {
+		c := slug[i]
+		if (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+// sortedSlugs returns the members of a reserved set in sorted order, as a fresh
+// slice so a caller cannot mutate the set through the accessor.
+func sortedSlugs(set map[string]struct{}) []string {
+	slugs := make([]string, 0, len(set))
+	for slug := range set {
+		slugs = append(slugs, slug)
+	}
+	sort.Strings(slugs)
+	return slugs
+}


### PR DESCRIPTION
## Description

This change introduces a shared, well-defined slug validation system for projects and organisations, along with explicit reserved-word policies tailored to each namespace.

The main motivation is to make slugs safe, stable, and predictable before they become part of public URLs, routing rules, API contracts, and database uniqueness constraints. Tightening these rules later would risk breaking stored references and existing routes, so establishing canonical validation now avoids long-term compatibility issues.

Organisation and project slugs now share the same formatting guarantees:
- lowercase, URL-safe identifiers
- no ambiguous variants such as repeated or trailing hyphens
- rejection of ObjectID-shaped values to avoid route ambiguity

At the same time, each slug type keeps its own reserved-word set because they occupy different routing scopes. Organisation slugs are globally unique and appear at the outermost URL segment, so they reserve a broader set of platform, infrastructure, and navigation terms to prevent collisions and namespace squatting. Project slugs remain more permissive because their uniqueness is scoped per organisation.

The extensive test coverage documents the intended behavior and protects against accidental rule drift. The tests specifically guard:
- canonical formatting rules
- reserved-word enforcement
- case-sensitivity assumptions
- separation between organisation and project policies
- immutability of exported reserved-slug lists
- consistency of the shared validation engine

Overall, this improves the project by making slug behavior explicit, enforceable, and future-proof across services, routing, and persistence layers.