### PR TITLE
feat(projectscope): define the shared project read predicate

### DIFF
--- a/pkg/models/projectscope.go
+++ b/pkg/models/projectscope.go
@@ -1,8 +1,11 @@
 package models
 
-import "go.mongodb.org/mongo-driver/bson/primitive"
+import (
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
 
-// The two helpers below define which project owns an organisation's resources
+// The helpers below define which project owns an organisation's resources
 // during the hidden single-project rollout.
 //
 // The rollout has no project UI, no switcher, and no API surface, so there is
@@ -51,4 +54,70 @@ func ResolveProjectId(organisationId primitive.ObjectID, stored *primitive.Objec
 		return *stored
 	}
 	return DefaultProjectId(organisationId)
+}
+
+// ProjectScopeFilter returns the clause a reader adds to narrow an
+// organisation's documents to one project.
+//
+// It is the read half of ResolveProjectId, and it lives here for the same
+// reason that function does: a writer stamps whatever ResolveProjectId returns,
+// and a reader must match exactly that. Split the two across modules and they
+// drift — silently, because a predicate that no longer matches what was stamped
+// returns zero documents rather than an error. Keeping the pair in one file is
+// what makes the drift impossible.
+//
+// This is NOT a tenant boundary. It narrows within an organisation, so callers
+// must apply their own organisation clause alongside it; on its own it would
+// match another tenant's documents that happen to share a project id.
+//
+// The predicate has two shapes, and the asymmetry is deliberate:
+//
+//   - For a real project it is strict equality. Only documents explicitly
+//     stamped for that project belong to it.
+//   - For the organisation's default project it also matches documents with no
+//     project at all. Every document written before the project axis existed is
+//     unstamped, and the default project is where they belong; a strict clause
+//     would make the entire pre-rollout history vanish from the UI.
+//
+// Relaxing only for the default project is the important half. An unconditional
+// tolerance reads identically today — during the rollout every project IS the
+// organisation default — but the moment a second project exists it would make
+// that project's reads match every unstamped document in the organisation. That
+// is a cross-project leak that no test written today would catch, because today
+// there is no second project to catch it with.
+//
+// A zero project, or an organisation id that is not an ObjectID, yields nil:
+// "do not narrow". That degrades a read to organisation-wide rather than to
+// nothing, mirroring the writer's own degradation for an unresolvable
+// organisation. It is not a leak — the caller's organisation clause still
+// bounds the result — whereas failing to an unmatchable predicate would blank a
+// tenant's screen over a resolution glitch.
+//
+// The tolerant form carries both a null arm and an $exists arm even though
+// {projectId: nil} already matches a missing field in MongoDB. The redundancy
+// is intentional: it is the exact shape the Hub API already hand-rolls, so
+// those call sites can adopt this helper as a pure substitution with no
+// behaviour change to argue about in review.
+func ProjectScopeFilter(organisationId string, projectId primitive.ObjectID) bson.M {
+	if projectId.IsZero() {
+		return nil
+	}
+
+	organisation, err := primitive.ObjectIDFromHex(organisationId)
+	if err != nil {
+		return nil
+	}
+
+	// Asking DefaultProjectId rather than comparing the hex strings directly
+	// keeps this in step with the definition: if the default ever stops being
+	// the organisation id, the tolerance follows it automatically.
+	if DefaultProjectId(organisation) != projectId {
+		return bson.M{"projectId": projectId}
+	}
+
+	return bson.M{"$or": []bson.M{
+		{"projectId": projectId},
+		{"projectId": bson.M{"$exists": false}},
+		{"projectId": nil},
+	}}
 }

--- a/pkg/models/projectscope_test.go
+++ b/pkg/models/projectscope_test.go
@@ -1,8 +1,11 @@
 package models
 
 import (
+	"reflect"
+	"strings"
 	"testing"
 
+	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
@@ -49,5 +52,81 @@ func TestResolveProjectIdFallsBackForUnassignedResources(t *testing.T) {
 		if got := ResolveProjectId(organisationId, stored); got != organisationId {
 			t.Fatalf("ResolveProjectId(%s) = %s, want organisation default %s", name, got.Hex(), organisationId.Hex())
 		}
+	}
+}
+
+func TestProjectScopeFilterIsStrictForARealProject(t *testing.T) {
+	organisationId := primitive.NewObjectID()
+	projectId := primitive.NewObjectID()
+
+	got := ProjectScopeFilter(organisationId.Hex(), projectId)
+	want := bson.M{"projectId": projectId}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ProjectScopeFilter() = %v, want %v", got, want)
+	}
+}
+
+func TestProjectScopeFilterDoesNotRelaxForARealProject(t *testing.T) {
+	// This is the regression an unconditionally tolerant predicate would pass
+	// every other test in this file and still cause. Today every project is its
+	// organisation's default, so a null arm here is invisible; the day a second
+	// project exists, that arm makes this project's reads match every unstamped
+	// document in the organisation — documents that belong to the default
+	// project, not to this one.
+	organisationId := primitive.NewObjectID()
+	projectId := primitive.NewObjectID()
+
+	if _, relaxed := ProjectScopeFilter(organisationId.Hex(), projectId)["$or"]; relaxed {
+		t.Fatal("a real project must not match documents that carry no project")
+	}
+}
+
+func TestProjectScopeFilterRelaxesForTheDefaultProject(t *testing.T) {
+	// Everything written before the project axis existed is unstamped, and the
+	// default project is where it belongs. A strict clause here would erase an
+	// organisation's entire pre-rollout history from the UI.
+	organisationId := primitive.NewObjectID()
+	defaultProjectId := DefaultProjectId(organisationId)
+
+	got := ProjectScopeFilter(organisationId.Hex(), defaultProjectId)
+	want := bson.M{"$or": []bson.M{
+		{"projectId": defaultProjectId},
+		{"projectId": bson.M{"$exists": false}},
+		{"projectId": nil},
+	}}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ProjectScopeFilter() = %v, want %v", got, want)
+	}
+}
+
+func TestProjectScopeFilterDoesNotNarrowWithoutAResolvableProject(t *testing.T) {
+	// Both inputs mean the caller could not resolve a project. Returning nil
+	// degrades the read to organisation-wide, which the caller's own
+	// organisation clause still bounds. The alternative — a predicate that
+	// matches nothing — would blank a tenant's screen over a resolution glitch.
+	organisationId := primitive.NewObjectID()
+
+	for name, filter := range map[string]bson.M{
+		"zero project":              ProjectScopeFilter(organisationId.Hex(), primitive.NilObjectID),
+		"non-ObjectID organisation": ProjectScopeFilter("legacy-tenant", primitive.NewObjectID()),
+	} {
+		if filter != nil {
+			t.Fatalf("ProjectScopeFilter(%s) = %v, want nil", name, filter)
+		}
+	}
+}
+
+func TestProjectScopeFilterAcceptsAnUppercaseOrganisationId(t *testing.T) {
+	// The default-project test is a comparison against a parsed id rather than
+	// against the hex string, so a differently-cased id still resolves to the
+	// tolerant form. Comparing strings would silently fall through to the strict
+	// clause and hide every unstamped document.
+	organisationId := primitive.NewObjectID()
+	upper := strings.ToUpper(organisationId.Hex())
+
+	if _, relaxed := ProjectScopeFilter(upper, DefaultProjectId(organisationId))["$or"]; !relaxed {
+		t.Fatal("an uppercase organisation id must still resolve to the default project")
 	}
 }


### PR DESCRIPTION
## Description

Introduces `ProjectScopeFilter`, a shared read predicate that centralises how project-scoped documents are queried during the single-project rollout.

The main motivation is to keep the write and read paths coupled. `ResolveProjectId` defines how documents are stamped, while `ProjectScopeFilter` now defines how those same documents are retrieved. Keeping both rules in the same module prevents subtle drift where readers stop matching what writers produced — a failure mode that silently returns empty results instead of errors.

This also formalises an important distinction between default and non-default projects:
- Real projects only match explicitly stamped documents.
- The default project additionally matches unstamped legacy documents created before the project axis existed.

That asymmetry preserves historical data visibility while preventing future cross-project leakage once multiple projects exist. Without this distinction, introducing a second project could accidentally expose unstamped documents across project boundaries.

The change also standardises fallback behaviour for unresolved project contexts by degrading to organisation-wide reads instead of producing unmatchable predicates that would blank tenant data during resolution issues.

Comprehensive tests were added to lock in the intended behaviour, including regression coverage for future multi-project scenarios and edge cases such as uppercase organisation IDs.