### PR TITLE
feat(media-edit): carry project ownership

### DIFF
--- a/pkg/api/analysis.go
+++ b/pkg/api/analysis.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/uug-ai/models/pkg/models"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
 // AnalysisStatus represents specific status codes for analysis operations
@@ -373,6 +374,7 @@ type SubmitFaceRedactionRequest struct {
 	// on-demand PipelineEvent (event.Payload) or a hub-workflows stage dispatch
 	// (run.User) — i.e. the request is self-contained and transport agnostic.
 	OrganisationId      string                        `json:"organisationId,omitempty"`
+	ProjectId           *primitive.ObjectID           `json:"projectId,omitempty"`
 	CaseMediaId         string                        `json:"caseMediaId"`
 	SignedUrl           string                        `json:"signedUrl"`
 	FileName            string                        `json:"fileName"`
@@ -419,6 +421,7 @@ type CaseMediaStatusEvent struct {
 	TaskId         string                 `json:"taskId"`
 	CaseMediaId    string                 `json:"caseMediaId"`
 	OrganisationId string                 `json:"organisationId"`
+	ProjectId      *primitive.ObjectID    `json:"projectId,omitempty"`
 	Status         models.CaseMediaStatus `json:"status"`
 	StatusError    string                 `json:"statusError,omitempty"`
 	File           string                 `json:"file,omitempty"`

--- a/pkg/api/analysis_project_test.go
+++ b/pkg/api/analysis_project_test.go
@@ -1,0 +1,30 @@
+package api
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/uug-ai/models/pkg/models"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+func TestMediaEditContractsCarryProjectOwnership(t *testing.T) {
+	projectId := primitive.NewObjectID()
+	contracts := []any{
+		SubmitFaceRedactionRequest{OrganisationId: primitive.NewObjectID().Hex(), ProjectId: &projectId},
+		CaseMediaStatusEvent{OrganisationId: primitive.NewObjectID().Hex(), ProjectId: &projectId, Status: models.CaseMediaStatusProcessing},
+	}
+	for _, contract := range contracts {
+		data, err := json.Marshal(contract)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var document map[string]any
+		if err := json.Unmarshal(data, &document); err != nil {
+			t.Fatal(err)
+		}
+		if document["projectId"] != projectId.Hex() {
+			t.Fatalf("projectId = %#v, want %s for %T", document["projectId"], projectId.Hex(), contract)
+		}
+	}
+}


### PR DESCRIPTION
## Description

This change propagates `projectId` through the media edit analysis contracts so project ownership is preserved across face redaction requests and case media status events.

By including `projectId` in these payloads, downstream services can consistently associate media processing operations with the correct project context. This improves traceability, ownership enforcement, and enables project-scoped workflows without relying solely on organisation-level metadata.

The added contract tests ensure `projectId` is serialized correctly in API payloads, protecting compatibility between services and preventing regressions in event propagation.