### PR TITLE
feat(project): mint the default project as "Project 1" / project-1

### DIFF
--- a/pkg/models/organisationslug_test.go
+++ b/pkg/models/organisationslug_test.go
@@ -152,12 +152,19 @@ func TestOrganisationAndProjectSlugSetsAreIndependent(t *testing.T) {
 		t.Fatal("no organisation-only reserved slugs, want the sets to differ")
 	}
 
-	// The default project slug is reserved for projects because a real document
-	// holds it. Nothing holds it for organisations, but an organisation called
-	// "default" reads as "no organisation" everywhere the project sentinel reads
-	// as "no project", so it is reserved on both sides for different reasons.
-	if !IsReservedOrganisationSlug(DefaultProjectSlug) {
-		t.Errorf("IsReservedOrganisationSlug(%q) = false, want true", DefaultProjectSlug)
+	// The sentinel words are reserved on both sides, for different reasons: an
+	// organisation called "default" reads as "no organisation" everywhere a
+	// project called "default" reads as "no project". DefaultProjectSlug itself
+	// is deliberately *not* checked here — it names a real document only on the
+	// project side, and nothing mints an organisation slug, so there is no reason
+	// for the organisation set to carry it.
+	for _, sentinel := range []string{"default", "none", "all"} {
+		if !IsReservedOrganisationSlug(sentinel) {
+			t.Errorf("IsReservedOrganisationSlug(%q) = false, want true", sentinel)
+		}
+		if !IsReservedProjectSlug(sentinel) {
+			t.Errorf("IsReservedProjectSlug(%q) = false, want true", sentinel)
+		}
 	}
 }
 

--- a/pkg/models/project.go
+++ b/pkg/models/project.go
@@ -14,11 +14,26 @@ type Project struct {
 	Audit          Audit              `json:"audit" bson:"audit"`
 }
 
-// DefaultProjectSlug is the reserved slug of the single default project minted
-// per organisation. The default project is the sentinel-free "organisation-wide"
-// selection: it is a real document (never a stored NilObjectID) so a user's
-// active project can always point at something concrete.
-const DefaultProjectSlug = "default"
+// DefaultProjectSlug and DefaultProjectName identify the single default project
+// minted per organisation. The default project is the sentinel-free
+// "organisation-wide" selection: it is a real document (never a stored
+// NilObjectID) so a user's active project can always point at something
+// concrete.
+//
+// The slug reads as an ordinary first project rather than as a sentinel,
+// deliberately: a slug that looks like a system value invites code that
+// special-cases it as one. It is reserved all the same — see
+// IsReservedProjectSlug — so only the server can mint it and nothing can rename
+// itself onto it. The name is not protected: a user may rename their own
+// default, and this is only the value it is minted with.
+//
+// Both constants live here, rather than as literals at each write site, because
+// a document written by the bulk migration and one minted lazily by Hub API are
+// supposed to be interchangeable.
+const (
+	DefaultProjectSlug = "project-1"
+	DefaultProjectName = "Project 1"
+)
 
 // GetProjectsInput lists the projects in the caller's active organisation.
 // Soft-deleted (inactive) projects are omitted unless IncludeInactive is set.

--- a/pkg/models/projectslug.go
+++ b/pkg/models/projectslug.go
@@ -25,10 +25,11 @@ const MaxProjectSlugLength = maxSlugLength
 // The groups below are the reasons a word is here; they are not a taxonomy
 // anyone needs to preserve when editing the list.
 var reservedProjectSlugs = map[string]struct{}{
-	// The default project identity, plus the words that read as "no project" or
-	// "every project". A slug that looks like a sentinel invites code that
-	// special-cases it as one.
-	"default": {}, "none": {}, "null": {}, "nil": {}, "undefined": {},
+	// DefaultProjectSlug, which only the server may mint, plus the words that
+	// read as "no project" or "every project". A slug that looks like a sentinel
+	// invites code that special-cases it as one.
+	"project-1": {},
+	"default":   {}, "none": {}, "null": {}, "nil": {}, "undefined": {},
 	"all": {}, "any": {}, "unassigned": {},
 
 	// Path segments a future /<orgSlug>/<projectSlug> scheme would collide with,
@@ -64,7 +65,7 @@ var reservedProjectSlugs = map[string]struct{}{
 // two checks and this one cannot.
 //
 // The argument is case-sensitive and assumes canonical form. Pass it through
-// ValidateProjectSlugFormat first: without that, "Default" misses this check,
+// ValidateProjectSlugFormat first: without that, "Project-1" misses this check,
 // misses an exact comparison against DefaultProjectSlug, and misses a
 // byte-comparison unique index.
 func IsReservedProjectSlug(slug string) bool {

--- a/pkg/models/projectslug_test.go
+++ b/pkg/models/projectslug_test.go
@@ -43,6 +43,8 @@ func TestValidateProjectSlugFormatRejectsNonCanonicalForms(t *testing.T) {
 		{name: "leading space", slug: " warehouse-north"},
 		{name: "trailing space", slug: "warehouse-north "},
 		{name: "uppercase", slug: "Warehouse-North"},
+		{name: "default slug in another case", slug: "Project-1"},
+		{name: "default slug shouting", slug: "PROJECT-1"},
 		{name: "reserved slug in another case", slug: "Default"},
 		{name: "reserved slug shouting", slug: "DEFAULT"},
 		{name: "underscore", slug: "warehouse_north"},
@@ -114,7 +116,7 @@ func TestDefaultProjectSlugIsReserved(t *testing.T) {
 // on: this check assumes canonical input and is not a substitute for format
 // validation.
 func TestIsReservedProjectSlugIsCaseSensitive(t *testing.T) {
-	for _, slug := range []string{"Default", "DEFAULT", "Admin", "warehouse-north", ""} {
+	for _, slug := range []string{"Project-1", "PROJECT-1", "Default", "DEFAULT", "Admin", "warehouse-north", ""} {
 		if IsReservedProjectSlug(slug) {
 			t.Errorf("IsReservedProjectSlug(%q) = true, want false", slug)
 		}


### PR DESCRIPTION
## Description

This change renames the automatically minted default project from the sentinel-like `"default"` slug to the more natural `"project-1"` with the display name `"Project 1"`.

The previous slug blurred the line between a real project document and a special system value. Because `"default"` reads like a sentinel, it encourages implicit assumptions and special-case handling throughout the codebase and API surface. By minting the default project as `"project-1"` instead, the system treats it more clearly as an ordinary project that happens to be created automatically.

The change keeps the slug reserved server-side so users cannot collide with it, while still allowing the project name itself to remain user-editable. This preserves the guarantees around always having a concrete project document for organisation-wide selection without exposing sentinel semantics to users or future code.

The accompanying test updates strengthen the distinction between reserved sentinel words and reserved minted identifiers, and expand validation coverage around canonical casing for the new default slug.