### PR TITLE
perf(project): make the tolerant project clause index-bounded

### DIFF
--- a/pkg/models/projectscope.go
+++ b/pkg/models/projectscope.go
@@ -93,11 +93,22 @@ func ResolveProjectId(organisationId primitive.ObjectID, stored *primitive.Objec
 // bounds the result — whereas failing to an unmatchable predicate would blank a
 // tenant's screen over a resolution glitch.
 //
-// The tolerant form carries both a null arm and an $exists arm even though
-// {projectId: nil} already matches a missing field in MongoDB. The redundancy
-// is intentional: it is the exact shape the Hub API already hand-rolls, so
-// those call sites can adopt this helper as a pure substitution with no
-// behaviour change to argue about in review.
+// The tolerant form is a two-element $in rather than an $or over an equality,
+// an $exists and a null arm. All three shapes select the same documents —
+// {projectId: nil} already matches a missing field in MongoDB, so the $exists
+// arm never added a document — but only the $in is answerable from an index.
+// A branch testing {$exists: false} cannot be: a missing field and an explicit
+// null are stored as the same index entry, so the planner cannot decide the
+// difference without fetching the document, and an AND-ed clause it cannot
+// push into an index turns an otherwise-indexed read into a full collection
+// scan followed by a blocking sort. The $in yields two point bounds instead,
+// which is what lets a reader keep using an existing {organisationId, sort key}
+// index.
+//
+// The redundant $or shape this replaces was chosen so the Hub API call sites
+// that hand-rolled it could adopt this helper as a pure substitution. They have
+// all adopted it, so that reason is spent and the shape is now free to be the
+// one the planner can use.
 func ProjectScopeFilter(organisationId string, projectId primitive.ObjectID) bson.M {
 	if projectId.IsZero() {
 		return nil
@@ -115,9 +126,5 @@ func ProjectScopeFilter(organisationId string, projectId primitive.ObjectID) bso
 		return bson.M{"projectId": projectId}
 	}
 
-	return bson.M{"$or": []bson.M{
-		{"projectId": projectId},
-		{"projectId": bson.M{"$exists": false}},
-		{"projectId": nil},
-	}}
+	return bson.M{"projectId": bson.M{"$in": bson.A{projectId, nil}}}
 }

--- a/pkg/models/projectscope_test.go
+++ b/pkg/models/projectscope_test.go
@@ -77,9 +77,35 @@ func TestProjectScopeFilterDoesNotRelaxForARealProject(t *testing.T) {
 	organisationId := primitive.NewObjectID()
 	projectId := primitive.NewObjectID()
 
-	if _, relaxed := ProjectScopeFilter(organisationId.Hex(), projectId)["$or"]; relaxed {
+	if toleratesUnstampedDocuments(ProjectScopeFilter(organisationId.Hex(), projectId)) {
 		t.Fatal("a real project must not match documents that carry no project")
 	}
+}
+
+// toleratesUnstampedDocuments reports whether a clause would select a document
+// that carries no projectId at all.
+//
+// It reads the predicate's meaning rather than its spelling. The tolerant form
+// has been an $or over an $exists arm and is now a two-element $in; both select
+// the same documents, and it is that selection — not the syntax — these tests
+// exist to pin down.
+func toleratesUnstampedDocuments(filter bson.M) bool {
+	// A bare equality never matches an absent field.
+	operators, ok := filter["projectId"].(bson.M)
+	if !ok {
+		return false
+	}
+	candidates, ok := operators["$in"].(bson.A)
+	if !ok {
+		return false
+	}
+	for _, candidate := range candidates {
+		// null matches both an explicit null and a missing field.
+		if candidate == nil {
+			return true
+		}
+	}
+	return false
 }
 
 func TestProjectScopeFilterRelaxesForTheDefaultProject(t *testing.T) {
@@ -90,14 +116,36 @@ func TestProjectScopeFilterRelaxesForTheDefaultProject(t *testing.T) {
 	defaultProjectId := DefaultProjectId(organisationId)
 
 	got := ProjectScopeFilter(organisationId.Hex(), defaultProjectId)
-	want := bson.M{"$or": []bson.M{
-		{"projectId": defaultProjectId},
-		{"projectId": bson.M{"$exists": false}},
-		{"projectId": nil},
-	}}
+	want := bson.M{"projectId": bson.M{"$in": bson.A{defaultProjectId, nil}}}
 
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("ProjectScopeFilter() = %v, want %v", got, want)
+	}
+}
+
+// The tolerant clause must stay a single key holding point-matchable values.
+// An $exists arm, or any other operator the planner cannot turn into index
+// bounds, selects exactly the same documents but forces the reader that ANDs
+// this clause onto an organisation scope into a full collection scan.
+func TestProjectScopeFilterTolerantFormIsIndexBounded(t *testing.T) {
+	organisationId := primitive.NewObjectID()
+
+	filter := ProjectScopeFilter(organisationId.Hex(), DefaultProjectId(organisationId))
+	if len(filter) != 1 {
+		t.Fatalf("tolerant filter must be a single key, got %v", filter)
+	}
+
+	candidates, ok := filter["projectId"].(bson.M)["$in"].(bson.A)
+	if !ok {
+		t.Fatalf("tolerant filter must narrow projectId with $in, got %v", filter)
+	}
+	for _, candidate := range candidates {
+		if candidate == nil {
+			continue
+		}
+		if _, isOperator := candidate.(bson.M); isOperator {
+			t.Fatalf("$in must hold plain values, got operator %v", candidate)
+		}
 	}
 }
 
@@ -126,7 +174,7 @@ func TestProjectScopeFilterAcceptsAnUppercaseOrganisationId(t *testing.T) {
 	organisationId := primitive.NewObjectID()
 	upper := strings.ToUpper(organisationId.Hex())
 
-	if _, relaxed := ProjectScopeFilter(upper, DefaultProjectId(organisationId))["$or"]; !relaxed {
+	if !toleratesUnstampedDocuments(ProjectScopeFilter(upper, DefaultProjectId(organisationId))) {
 		t.Fatal("an uppercase organisation id must still resolve to the default project")
 	}
 }


### PR DESCRIPTION
## Description

The tolerant project scope clause currently uses an `$or` combining equality, `$exists: false`, and `null` checks. While functionally correct, that shape prevents MongoDB from answering the predicate from an index, forcing full collection scans and blocking sorts when combined with organisation-scoped reads.

This change replaces the tolerant clause with a two-value `$in`:

- before: `$or` over `projectId == value`, `projectId missing`, and `projectId == null`
- after: `projectId: { $in: [value, null] }`

The new form preserves behaviour because `{projectId: null}` already matches missing fields in MongoDB. The `$exists` branch was therefore redundant, but still expensive because it could not be index-bounded.

By switching to `$in`, the query planner can generate point bounds and continue using existing indexes such as `{organisationId, sortKey}`. This improves read performance for tolerant project-scoped queries without changing which documents are returned.

The test suite was updated to validate predicate semantics rather than BSON shape, and new coverage ensures the tolerant form remains index-friendly going forward.