### PR TITLE
perf(pagination): make the total count opt-in

### DIFF
--- a/pkg/api/pagination.go
+++ b/pkg/api/pagination.go
@@ -5,6 +5,21 @@ type CursorPagination struct {
 	Cursor string `json:"cursor,omitempty" bson:"cursor,omitempty"`
 	Limit  int64  `json:"limit,omitempty" bson:"limit,omitempty"`
 
+	// IncludeTotal asks the server to also count everything the filter matches,
+	// not just the page being returned, and report it as Total.
+	//
+	// It is opt-in because the count is a second query over the whole matched
+	// set while the page itself stops at Limit, so its cost scales with the
+	// tenant rather than with the response. Most callers page for display and
+	// never read Total; making them pay for it is how a cheap list turns into
+	// an expensive one, and it is why this defaults to off.
+	//
+	// A caller that omits it gets Total unset rather than zero-as-a-count:
+	// Total is omitempty, so "not asked for" and "asked for, and the answer is
+	// nought" are the same wire value. Callers that need to tell the two apart
+	// must rely on having asked.
+	IncludeTotal bool `json:"includeTotal,omitempty" bson:"includeTotal,omitempty"`
+
 	// Response fields (returned by server)
 	NextCursor string `json:"nextCursor,omitempty" bson:"nextCursor,omitempty"`
 	PrevCursor string `json:"prevCursor,omitempty" bson:"prevCursor,omitempty"`
@@ -13,7 +28,9 @@ type CursorPagination struct {
 	// Optional numbered pagination support
 	Page     int64 `json:"page,omitempty" bson:"page,omitempty"`
 	PageSize int64 `json:"pageSize,omitempty" bson:"pageSize,omitempty"`
-	Total    int64 `json:"total,omitempty" bson:"total,omitempty"`
+	// Total is the size of the whole matched set, populated only when the
+	// request set IncludeTotal. It is not the length of the page.
+	Total int64 `json:"total,omitempty" bson:"total,omitempty"`
 }
 
 // PaginationRequest/response ?

--- a/pkg/api/pagination_test.go
+++ b/pkg/api/pagination_test.go
@@ -1,0 +1,60 @@
+package api
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// A client that says nothing about the total must not be read as asking for
+// one. The field is the difference between a page read and a whole-tenant
+// count, so the zero value has to mean "no" on the wire as well as in Go.
+func TestCursorPaginationOmitsIncludeTotalWhenUnset(t *testing.T) {
+	encoded, err := json.Marshal(CursorPagination{Cursor: "abc", Limit: 25})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(encoded), "includeTotal") {
+		t.Errorf("an unset IncludeTotal reached the wire: %s", encoded)
+	}
+
+	var decoded CursorPagination
+	if err := json.Unmarshal([]byte(`{"cursor":"abc","limit":25}`), &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if decoded.IncludeTotal {
+		t.Error("a request that omitted includeTotal decoded as asking for a total")
+	}
+}
+
+func TestCursorPaginationCarriesIncludeTotalWhenRequested(t *testing.T) {
+	encoded, err := json.Marshal(CursorPagination{Limit: 25, IncludeTotal: true})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(encoded), `"includeTotal":true`) {
+		t.Errorf("IncludeTotal did not reach the wire: %s", encoded)
+	}
+
+	var decoded CursorPagination
+	if err := json.Unmarshal([]byte(`{"limit":25,"includeTotal":true}`), &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !decoded.IncludeTotal {
+		t.Error("includeTotal:true did not decode as asking for a total")
+	}
+}
+
+// Total is omitempty, so a zero total is indistinguishable on the wire from a
+// total that was never requested. That is tolerable only because a caller knows
+// whether it asked; this pins the ambiguity rather than leaving it to be
+// discovered by a client reading a missing total as "no results".
+func TestCursorPaginationOmitsZeroTotal(t *testing.T) {
+	encoded, err := json.Marshal(CursorPagination{HasMore: false, Total: 0})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(encoded), "total") {
+		t.Errorf("a zero total reached the wire: %s", encoded)
+	}
+}


### PR DESCRIPTION
## Description

Counting the full result set for every paginated request adds a second query whose cost scales with the size of the tenant, not the size of the page being returned. Most consumers only need the current page of results, so always computing `Total` turns otherwise cheap list operations into unnecessarily expensive ones.

This change makes total counts opt-in through a new `IncludeTotal` request field. Clients that need the full matched count can explicitly request it, while all other callers avoid the extra database work by default. This improves scalability and reduces the baseline cost of paginated endpoints without removing existing functionality.

The update also clarifies the API contract around `Total`, documenting that it is only populated when explicitly requested and that it represents the size of the full matched set rather than the current page size.

Additional serialization tests were added to lock in the wire behavior and prevent regressions around omitted fields and `omitempty` semantics.