### PR TITLE
refactor(subscription): own the ownership filter and read order

### DIFF
--- a/pkg/models/subscriptionscope.go
+++ b/pkg/models/subscriptionscope.go
@@ -1,0 +1,63 @@
+package models
+
+import (
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+// SubscriptionOwnershipFilter selects the subscriptions an organisation owns.
+//
+// Ownership is recorded two ways. Canonical documents carry organisation_id.
+// Documents predating the organisation model carry only user_id, holding the
+// hex of what is now the organisation id — organisations were minted at the
+// owning user's id, so the two strings coincide. The Hub API backfills
+// organisation_id opportunistically, on cancel, resume and upgrade, so the
+// migration is lazy and incomplete by construction: both arms stay load-bearing
+// until a backfill retires the second one.
+//
+// The legacy arm keeps the organisation_id $exists test, and that test is a
+// tenant guard rather than a narrowing optimisation. Drop it and a subscription
+// owned by organisation B whose legacy user_id happens to be A's hex matches a
+// read for A. Only a backfill that leaves no document without organisation_id
+// makes the arm safe to remove.
+//
+// Both arms are index-bounded on purpose. MongoDB serves an $or from indexes
+// only when every arm applies its bounds at index level; one unindexed arm
+// collapses the whole $or to a collection scan, so the arms are a pair rather
+// than two independent predicates. The legacy arm rides a {user_id} index with
+// the $exists as a cheap residual, and the canonical arm needs an index leading
+// with organisation_id.
+func SubscriptionOwnershipFilter(organisationId primitive.ObjectID) bson.M {
+	return bson.M{"$or": bson.A{
+		bson.M{"organisation_id": organisationId},
+		bson.M{
+			"organisation_id": bson.M{"$exists": false},
+			"user_id":         organisationId.Hex(),
+		},
+	}}
+}
+
+// LatestSubscriptionSort orders subscriptions newest-first.
+//
+// An organisation legitimately owns more than one: an upgrade or a
+// cancel-then-resume leaves the superseded documents in place, and they remain
+// active by the ends_at test. Without an order a single-document read resolves
+// to whichever one the query plan reaches first, which makes the answer a
+// function of the index set rather than of the data — adding or dropping an
+// index then silently changes which subscription a tenant gets.
+//
+// created_at breaks the tie between documents written in the same instant, and
+// _id between documents old enough to predate created_at. Missing values sort
+// lowest in MongoDB, so descending puts them last: a document no modern write
+// path has touched loses to one that has.
+//
+// These are the trailing keys of the {organisation_id, updated_at, created_at,
+// _id} index, so a reader pairing this with SubscriptionOwnershipFilter is
+// ordered from the index rather than by a blocking in-memory sort.
+func LatestSubscriptionSort() bson.D {
+	return bson.D{
+		{Key: "updated_at", Value: -1},
+		{Key: "created_at", Value: -1},
+		{Key: "_id", Value: -1},
+	}
+}

--- a/pkg/models/subscriptionscope_test.go
+++ b/pkg/models/subscriptionscope_test.go
@@ -1,0 +1,78 @@
+package models
+
+import (
+	"reflect"
+	"testing"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+func TestSubscriptionOwnershipFilterUsesCanonicalBeforeLegacyFallback(t *testing.T) {
+	organisationId := primitive.NewObjectID()
+
+	want := bson.M{"$or": bson.A{
+		bson.M{"organisation_id": organisationId},
+		bson.M{
+			"organisation_id": bson.M{"$exists": false},
+			"user_id":         organisationId.Hex(),
+		},
+	}}
+
+	if got := SubscriptionOwnershipFilter(organisationId); !reflect.DeepEqual(got, want) {
+		t.Fatalf("SubscriptionOwnershipFilter() = %#v, want %#v", got, want)
+	}
+}
+
+func TestSubscriptionOwnershipFilterGuardsTheLegacyArm(t *testing.T) {
+	// The $exists test is what keeps the legacy arm from being a cross-tenant
+	// leak: without it, a subscription owned by another organisation whose
+	// legacy user_id happens to be this organisation's hex would match. It is
+	// asserted on its own because a "simplification" that collapses the filter
+	// to {$or: [{organisation_id: id}, {user_id: hex}]} selects the same
+	// documents in every test fixture that has no such collision.
+	organisationId := primitive.NewObjectID()
+
+	arms, ok := SubscriptionOwnershipFilter(organisationId)["$or"].(bson.A)
+	if !ok || len(arms) != 2 {
+		t.Fatalf("filter is not a two-armed $or: %#v", SubscriptionOwnershipFilter(organisationId))
+	}
+
+	legacy, ok := arms[1].(bson.M)
+	if !ok {
+		t.Fatalf("legacy arm = %#v, want bson.M", arms[1])
+	}
+	if !reflect.DeepEqual(legacy["organisation_id"], bson.M{"$exists": false}) {
+		t.Fatalf("legacy arm organisation_id guard = %#v, want {$exists: false}", legacy["organisation_id"])
+	}
+	if legacy["user_id"] != organisationId.Hex() {
+		t.Fatalf("legacy arm user_id = %v, want %s", legacy["user_id"], organisationId.Hex())
+	}
+}
+
+func TestLatestSubscriptionSortIsNewestFirst(t *testing.T) {
+	// Order and direction are both load-bearing. The keys are the trailing keys
+	// of the {organisation_id, updated_at, created_at, _id} index, so any
+	// reordering costs the readers their index-served sort and gives them a
+	// blocking in-memory one instead.
+	want := bson.D{
+		{Key: "updated_at", Value: -1},
+		{Key: "created_at", Value: -1},
+		{Key: "_id", Value: -1},
+	}
+
+	if got := LatestSubscriptionSort(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("LatestSubscriptionSort() = %#v, want %#v", got, want)
+	}
+}
+
+func TestLatestSubscriptionSortIsNotAliased(t *testing.T) {
+	// bson.D is a slice, so returning a package-level value would let one
+	// caller's SetSort mutate every other caller's order.
+	first := LatestSubscriptionSort()
+	first[0].Key = "mutated"
+
+	if got := LatestSubscriptionSort(); got[0].Key != "updated_at" {
+		t.Fatalf("LatestSubscriptionSort() leading key = %q after a caller mutated an earlier result", got[0].Key)
+	}
+}


### PR DESCRIPTION
## Description

This refactor centralises subscription ownership filtering and read ordering into dedicated model helpers, making the rules around subscription lookup explicit, reusable, and testable.

The ownership filter now captures both canonical subscriptions (`organisation_id`) and legacy documents (`user_id`) in one place, including the critical tenant-safety guard that prevents cross-organisation matches during the migration period. Encoding this logic once reduces the risk of future queries accidentally dropping the legacy protection or diverging from the intended migration behaviour.

The change also introduces a stable “latest subscription” sort order. Subscription reads previously depended on whichever document the query planner encountered first, meaning index changes could silently alter which subscription an organisation received. The new ordering makes selection deterministic and aligned with the backing index, avoiding unstable reads and preventing unnecessary in-memory sorts.

Comprehensive tests were added to lock down the behaviour, especially around tenant isolation, ordering guarantees, and mutation safety for returned BSON sort definitions.