### PR TITLE
feat(subscription): own the active-window filter

### DIFF
--- a/pkg/models/subscriptionscope.go
+++ b/pkg/models/subscriptionscope.go
@@ -1,6 +1,8 @@
 package models
 
 import (
+	"time"
+
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
@@ -34,6 +36,34 @@ func SubscriptionOwnershipFilter(organisationId primitive.ObjectID) bson.M {
 			"organisation_id": bson.M{"$exists": false},
 			"user_id":         organisationId.Hex(),
 		},
+	}}
+}
+
+// ActiveSubscriptionFilter selects the subscriptions that have not lapsed.
+//
+// A subscription is active while ends_at lies in the future, and indefinitely
+// while ends_at is unset — an open-ended subscription is the normal state, and
+// cancelling is what writes the field. Resuming clears it again, so a document
+// moves between the two arms over its life rather than belonging to one.
+//
+// The nil comparison is doing more work than it looks. MongoDB matches both an
+// explicit null and a missing key, which is what makes the second arm cover the
+// never-cancelled documents that carry no ends_at at all. Rewriting it as an
+// $exists test would quietly drop the ones holding an explicit null.
+//
+// Callers pass the instant rather than letting this read the clock, so a query
+// built from several parts compares every one of them against the same now, and
+// so a test can pick an instant either side of a fixture's ends_at.
+//
+// Pair this with SubscriptionOwnershipFilter and the {organisation_id, ends_at}
+// and {user_id, ends_at} indexes cover the result. Note this is a read-side
+// filter only: a write that has to find a cancelled subscription in order to
+// resume it must not apply it, or the document it exists to revive is exactly
+// the one it excludes.
+func ActiveSubscriptionFilter(now time.Time) bson.M {
+	return bson.M{"$or": bson.A{
+		bson.M{"ends_at": bson.M{"$gt": now}},
+		bson.M{"ends_at": nil},
 	}}
 }
 

--- a/pkg/models/subscriptionscope_test.go
+++ b/pkg/models/subscriptionscope_test.go
@@ -3,6 +3,7 @@ package models
 import (
 	"reflect"
 	"testing"
+	"time"
 
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
@@ -47,6 +48,57 @@ func TestSubscriptionOwnershipFilterGuardsTheLegacyArm(t *testing.T) {
 	}
 	if legacy["user_id"] != organisationId.Hex() {
 		t.Fatalf("legacy arm user_id = %v, want %s", legacy["user_id"], organisationId.Hex())
+	}
+}
+
+func TestActiveSubscriptionFilterCoversOpenEndedSubscriptions(t *testing.T) {
+	now := time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC)
+
+	want := bson.M{"$or": bson.A{
+		bson.M{"ends_at": bson.M{"$gt": now}},
+		bson.M{"ends_at": nil},
+	}}
+
+	if got := ActiveSubscriptionFilter(now); !reflect.DeepEqual(got, want) {
+		t.Fatalf("ActiveSubscriptionFilter() = %#v, want %#v", got, want)
+	}
+}
+
+func TestActiveSubscriptionFilterMatchesAbsentEndsAtViaNil(t *testing.T) {
+	// The nil arm is load-bearing in a way an $exists rewrite would break in one
+	// direction only. MongoDB matches nil against both an explicit null and a
+	// missing key, so this one arm covers the never-cancelled documents that
+	// carry no ends_at and the resumed ones that carry null. {$exists: false}
+	// would silently drop the latter, and every fixture built by resuming a
+	// subscription would stop matching.
+	arms, ok := ActiveSubscriptionFilter(time.Now())["$or"].(bson.A)
+	if !ok || len(arms) != 2 {
+		t.Fatalf("filter is not a two-armed $or: %#v", ActiveSubscriptionFilter(time.Now()))
+	}
+
+	openEnded, ok := arms[1].(bson.M)
+	if !ok {
+		t.Fatalf("open-ended arm = %#v, want bson.M", arms[1])
+	}
+	endsAt, present := openEnded["ends_at"]
+	if !present {
+		t.Fatalf("open-ended arm does not test ends_at: %#v", openEnded)
+	}
+	if endsAt != nil {
+		t.Fatalf("open-ended arm ends_at = %#v, want a literal nil rather than an operator document", endsAt)
+	}
+}
+
+func TestActiveSubscriptionFilterUsesTheCallersInstant(t *testing.T) {
+	// The instant is a parameter so a query assembled from several parts compares
+	// all of them against one now. Reading the clock here would also make the
+	// filter untestable against a fixture's ends_at.
+	past := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	arms := ActiveSubscriptionFilter(past)["$or"].(bson.A)
+	active := arms[0].(bson.M)["ends_at"].(bson.M)
+	if active["$gt"] != past {
+		t.Fatalf("active arm compares against %#v, want the caller's instant %v", active["$gt"], past)
 	}
 }
 


### PR DESCRIPTION
## Description

This change introduces a dedicated `ActiveSubscriptionFilter` for querying subscriptions that are still valid. Centralising this logic removes duplicated “active window” checks from callers and makes the rules around subscription activity explicit and reusable.

The filter correctly handles both time-bounded subscriptions and open-ended subscriptions where `ends_at` is unset or null. That distinction is important in MongoDB, where matching against `nil` covers both missing and explicitly null fields. Encoding this behaviour in one place reduces the risk of subtle regressions from future query rewrites.

The implementation also takes the comparison instant as a parameter instead of reading the clock internally. This keeps multi-part queries consistent, improves determinism, and makes the behaviour straightforward to test.

The accompanying tests lock down the load-bearing parts of the query structure and document the edge cases around MongoDB null semantics, helping prevent accidental changes that would silently exclude valid subscriptions.