### PR TITLE
fix(device): clarify project ownership contract

### DIFF
--- a/pkg/models/device.go
+++ b/pkg/models/device.go
@@ -38,9 +38,9 @@ type Device struct {
 	SiteIds        []string `json:"siteIds" bson:"siteIds,omitempty"`
 	GroupIds       []string `json:"groupIds" bson:"groupIds,omitempty"`
 
-	// ProjectId optionally places the device in a project within its
-	// organisation. A nil value keeps the device organisation-wide. It narrows
-	// access on top of OrganisationId; it never replaces it.
+	// ProjectId places the device in exactly one project within its organisation.
+	// A nil or zero legacy value resolves to that organisation's default project;
+	// it does not make the device organisation-wide.
 	ProjectId *primitive.ObjectID `json:"projectId,omitempty" bson:"projectId,omitempty"`
 
 	// @LEGACY FIELDS - to be removed in future versions

--- a/src/typescript/types.ts
+++ b/src/typescript/types.ts
@@ -33545,9 +33545,9 @@ export interface components {
              *     OrganisationId is used to identify the organisation that owns the device.
              *     FeaturePermissions is used to identify the permissions of the device, such as read, write, delete, etc. */
             organisationId?: string;
-            /** @description ProjectId optionally places the device in a project within its
-             *     organisation. A nil value keeps the device organisation-wide. It narrows
-             *     access on top of OrganisationId; it never replaces it. */
+            /** @description ProjectId places the device in exactly one project within its organisation.
+             *     A nil or zero legacy value resolves to that organisation's default project;
+             *     it does not make the device organisation-wide. */
             projectId?: string;
             /** @description Versioning information
              *     Note: Version is used to identify the version of the device software.


### PR DESCRIPTION
## Description

This change clarifies the ownership model for devices by correcting outdated documentation around `ProjectId`.

The previous comments implied that a device could exist organisation-wide when `ProjectId` was nil. In practice, devices always belong to exactly one project, and legacy nil or zero values are resolved to the organisation’s default project. The old wording created ambiguity around access control and ownership semantics.

Updating the Go model comments and generated TypeScript API documentation makes the contract explicit and consistent across backend and client integrations. This reduces the risk of incorrect assumptions in downstream services, simplifies reasoning about device access boundaries, and better reflects the actual system behaviour.