### PR TITLE
feat(pipeline): carry trusted source device identity

### DIFF
--- a/pkg/models/pipeline.go
+++ b/pkg/models/pipeline.go
@@ -244,9 +244,21 @@ type Stage interface {
 }
 
 type EventStage struct {
-	Name      string `json:"name,omitempty"`
-	EventData string `json:"eventData,omitempty"` // Add fields relevant to event stage
+	Name         string                `json:"name,omitempty"`
+	EventData    string                `json:"eventData,omitempty"` // Add fields relevant to event stage
+	SourceDevice *PipelineSourceDevice `json:"sourceDevice,omitempty"`
 	// Add more fields as needed
+}
+
+// PipelineSourceDevice is trusted ingress identity resolved from authenticated
+// credentials before an event enters the processing queues. DeviceKey remains
+// a consistency guard; DeviceId is the canonical registry identity. Legacy
+// events omit this block and follow explicit compatibility handling.
+type PipelineSourceDevice struct {
+	DeviceId       primitive.ObjectID  `json:"deviceId,omitempty"`
+	DeviceKey      string              `json:"deviceKey,omitempty"`
+	OrganisationId string              `json:"organisationId,omitempty"`
+	ProjectId      *primitive.ObjectID `json:"projectId,omitempty"`
 }
 
 // Constructor function for EventStage

--- a/pkg/models/pipeline.go
+++ b/pkg/models/pipeline.go
@@ -259,6 +259,7 @@ type PipelineSourceDevice struct {
 	DeviceKey      string              `json:"deviceKey,omitempty"`
 	OrganisationId string              `json:"organisationId,omitempty"`
 	ProjectId      *primitive.ObjectID `json:"projectId,omitempty"`
+	OwnerUserId    string              `json:"ownerUserId,omitempty"`
 }
 
 // Constructor function for EventStage

--- a/pkg/models/pipeline_test.go
+++ b/pkg/models/pipeline_test.go
@@ -90,6 +90,39 @@ func TestPipelineEventWithoutOwnershipSnapshotRemainsCompatible(t *testing.T) {
 	}
 }
 
+func TestPipelineSourceDeviceRoundTripsCanonicalIdentity(t *testing.T) {
+	deviceId := primitive.NewObjectID()
+	organisationId := primitive.NewObjectID()
+	projectId := primitive.NewObjectID()
+	event := PipelineEvent{
+		EventStage: &EventStage{SourceDevice: &PipelineSourceDevice{
+			DeviceId:       deviceId,
+			DeviceKey:      "device-1",
+			OrganisationId: organisationId.Hex(),
+			ProjectId:      &projectId,
+		}},
+	}
+
+	encoded, err := json.Marshal(event)
+	if err != nil {
+		t.Fatalf("marshal pipeline event: %v", err)
+	}
+	var decoded PipelineEvent
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatalf("unmarshal pipeline event: %v", err)
+	}
+	if decoded.EventStage == nil || decoded.EventStage.SourceDevice == nil {
+		t.Fatalf("source device = %#v", decoded.EventStage)
+	}
+	got := decoded.EventStage.SourceDevice
+	if got.DeviceId != deviceId || got.DeviceKey != "device-1" || got.OrganisationId != organisationId.Hex() {
+		t.Fatalf("source device = %#v", got)
+	}
+	if got.ProjectId == nil || *got.ProjectId != projectId {
+		t.Fatalf("source project = %v, want %s", got.ProjectId, projectId.Hex())
+	}
+}
+
 func TestPipelineEventOwnershipSnapshotAppliesToLegacyMedia(t *testing.T) {
 	organisationId := primitive.NewObjectID().Hex()
 	projectId := primitive.NewObjectID()

--- a/pkg/models/pipeline_test.go
+++ b/pkg/models/pipeline_test.go
@@ -94,12 +94,14 @@ func TestPipelineSourceDeviceRoundTripsCanonicalIdentity(t *testing.T) {
 	deviceId := primitive.NewObjectID()
 	organisationId := primitive.NewObjectID()
 	projectId := primitive.NewObjectID()
+	ownerUserId := primitive.NewObjectID()
 	event := PipelineEvent{
 		EventStage: &EventStage{SourceDevice: &PipelineSourceDevice{
 			DeviceId:       deviceId,
 			DeviceKey:      "device-1",
 			OrganisationId: organisationId.Hex(),
 			ProjectId:      &projectId,
+			OwnerUserId:    ownerUserId.Hex(),
 		}},
 	}
 
@@ -115,7 +117,7 @@ func TestPipelineSourceDeviceRoundTripsCanonicalIdentity(t *testing.T) {
 		t.Fatalf("source device = %#v", decoded.EventStage)
 	}
 	got := decoded.EventStage.SourceDevice
-	if got.DeviceId != deviceId || got.DeviceKey != "device-1" || got.OrganisationId != organisationId.Hex() {
+	if got.DeviceId != deviceId || got.DeviceKey != "device-1" || got.OrganisationId != organisationId.Hex() || got.OwnerUserId != ownerUserId.Hex() {
 		t.Fatalf("source device = %#v", got)
 	}
 	if got.ProjectId == nil || *got.ProjectId != projectId {

--- a/src/typescript/types.ts
+++ b/src/typescript/types.ts
@@ -33702,6 +33702,7 @@ export interface components {
             /** @description Add fields relevant to event stage */
             eventData?: string;
             name?: string;
+            sourceDevice?: components["schemas"]["models.PipelineSourceDevice"];
         };
         "models.ExportFile": {
             camera_id?: string;
@@ -34923,6 +34924,12 @@ export interface components {
             /** @description Signed URL */
             signedUrl?: string;
             timestamp?: number;
+        };
+        "models.PipelineSourceDevice": {
+            deviceId?: string;
+            deviceKey?: string;
+            organisationId?: string;
+            projectId?: string;
         };
         "models.Plan": {
             /** @description AnalysisLimit is the maximum number of analysis operations allowed */

--- a/src/typescript/types.ts
+++ b/src/typescript/types.ts
@@ -34929,6 +34929,7 @@ export interface components {
             deviceId?: string;
             deviceKey?: string;
             organisationId?: string;
+            ownerUserId?: string;
             projectId?: string;
         };
         "models.Plan": {


### PR DESCRIPTION
## Description

This change adds a trusted `sourceDevice` identity snapshot to pipeline events so downstream processing can rely on canonical device ownership and registry information resolved at ingress time.

Previously, pipeline events only carried loosely coupled identifiers such as `deviceKey`, which made it harder to consistently reason about device ownership, project association, and authenticated provenance once events entered asynchronous processing queues. By persisting the resolved device identity directly on the event, the pipeline gains a stable and authoritative source of truth that travels with the payload throughout processing.

The new `PipelineSourceDevice` model captures:
- Canonical device identity (`deviceId`)
- Consistency guard (`deviceKey`)
- Ownership and tenancy context (`organisationId`, `projectId`, `ownerUserId`)

This improves the project by:
- Reducing ambiguity in downstream authorization and ownership checks
- Making queued event processing more resilient to later registry changes
- Preserving trusted ingress context across async boundaries
- Providing a clearer migration path for legacy events through explicit compatibility handling

The PR also updates generated TypeScript types and adds round-trip serialization tests to ensure the new identity snapshot remains stable and backward compatible across API boundaries.