### PR TITLE
Carry source cloud-key locator

### DIFF
--- a/pkg/models/pipeline.go
+++ b/pkg/models/pipeline.go
@@ -250,13 +250,15 @@ type EventStage struct {
 	// Add more fields as needed
 }
 
-// PipelineSourceDevice is trusted ingress identity resolved from authenticated
-// credentials before an event enters the processing queues. DeviceKey remains
-// a consistency guard; DeviceId is the canonical registry identity. Legacy
-// events omit this block and follow explicit compatibility handling.
+// PipelineSourceDevice carries the source-device locator and any identity
+// resolved by trusted pipeline stages. Vault initially supplies CloudKey and
+// DeviceKey after authenticating the upload account. Monitor resolves and fills
+// the canonical fields before downstream persistence. Legacy events omit this
+// block and follow explicit compatibility handling.
 type PipelineSourceDevice struct {
 	DeviceId       primitive.ObjectID  `json:"deviceId,omitempty"`
 	DeviceKey      string              `json:"deviceKey,omitempty"`
+	CloudKey       string              `json:"cloudKey,omitempty"`
 	OrganisationId string              `json:"organisationId,omitempty"`
 	ProjectId      *primitive.ObjectID `json:"projectId,omitempty"`
 	OwnerUserId    string              `json:"ownerUserId,omitempty"`

--- a/pkg/models/pipeline_test.go
+++ b/pkg/models/pipeline_test.go
@@ -99,6 +99,7 @@ func TestPipelineSourceDeviceRoundTripsCanonicalIdentity(t *testing.T) {
 		EventStage: &EventStage{SourceDevice: &PipelineSourceDevice{
 			DeviceId:       deviceId,
 			DeviceKey:      "device-1",
+			CloudKey:       "cloud-key-1",
 			OrganisationId: organisationId.Hex(),
 			ProjectId:      &projectId,
 			OwnerUserId:    ownerUserId.Hex(),
@@ -117,7 +118,7 @@ func TestPipelineSourceDeviceRoundTripsCanonicalIdentity(t *testing.T) {
 		t.Fatalf("source device = %#v", decoded.EventStage)
 	}
 	got := decoded.EventStage.SourceDevice
-	if got.DeviceId != deviceId || got.DeviceKey != "device-1" || got.OrganisationId != organisationId.Hex() || got.OwnerUserId != ownerUserId.Hex() {
+	if got.DeviceId != deviceId || got.DeviceKey != "device-1" || got.CloudKey != "cloud-key-1" || got.OrganisationId != organisationId.Hex() || got.OwnerUserId != ownerUserId.Hex() {
 		t.Fatalf("source device = %#v", got)
 	}
 	if got.ProjectId == nil || *got.ProjectId != projectId {

--- a/src/typescript/types.ts
+++ b/src/typescript/types.ts
@@ -34926,6 +34926,7 @@ export interface components {
             timestamp?: number;
         };
         "models.PipelineSourceDevice": {
+            cloudKey?: string;
             deviceId?: string;
             deviceKey?: string;
             organisationId?: string;


### PR DESCRIPTION
## Description

This change extends `PipelineSourceDevice` to carry the original `CloudKey` alongside the resolved canonical device identity throughout the pipeline.

Previously, only the resolved `DeviceId` and `DeviceKey` were preserved after authentication and enrichment. Carrying the `CloudKey` keeps the original source-device locator available across pipeline stages, improving traceability between authenticated uploads and downstream processing.

The update also clarifies the ownership and lifecycle of identity fields in the model documentation:
- Vault authenticates uploads and provides `CloudKey` and `DeviceKey`
- Monitor resolves canonical registry identity fields before persistence

Tests were updated to validate round-trip serialization of the new field, and the generated TypeScript types now expose `cloudKey` to consumers, keeping API contracts aligned across services and clients.