### PR TITLE
feat(audit): add project context

### DIFF
--- a/pkg/models/auditevent.go
+++ b/pkg/models/auditevent.go
@@ -15,19 +15,32 @@ type AuditEvent struct {
 	Id primitive.ObjectID `json:"id" bson:"_id,omitempty"`
 	// OrganisationId scopes the event to a tenant for org-wide audit queries.
 	OrganisationId primitive.ObjectID `json:"organisationId" bson:"organisationId,omitempty"`
+	// ProjectId optionally narrows the event to a project within the organisation.
+	// Organisation-wide actions leave it nil.
+	ProjectId *primitive.ObjectID `json:"projectId,omitempty" bson:"projectId,omitempty"`
 	// ActorId is the user who performed the action; ActorName is denormalised so
 	// history can be rendered without a lookup.
 	ActorId   primitive.ObjectID `json:"actorId" bson:"actorId,omitempty"`
 	ActorName string             `json:"actorName,omitempty" bson:"actorName,omitempty"`
+	// ActorType identifies the principal kind, e.g. "user", "apikey" or "system".
+	ActorType string `json:"actorType,omitempty" bson:"actorType,omitempty"`
 	// Action is a short semantic label, e.g. "case.commented", "device.renamed",
 	// "member.suspended".
 	Action string `json:"action" bson:"action,omitempty"`
+	// Operation is the coarse CRUD-style action class.
+	Operation string `json:"operation,omitempty" bson:"operation,omitempty"`
+	// Category groups the action by subsystem.
+	Category string `json:"category,omitempty" bson:"category,omitempty"`
+	// Outcome records whether the action succeeded.
+	Outcome string `json:"outcome,omitempty" bson:"outcome,omitempty"`
 	// TargetType and TargetId identify the entity the action was performed on
 	// (e.g. TargetType "case" with the case id). Query these to render an
 	// entity's audit history. TargetId is a string so it can hold either an
-	// ObjectID hex or a non-ObjectID key (such as a media key).
+	// ObjectID hex or a non-ObjectID key (such as a media key). TargetName is the
+	// denormalised point-in-time label of the target.
 	TargetType string `json:"targetType" bson:"targetType,omitempty"`
 	TargetId   string `json:"targetId" bson:"targetId,omitempty"`
+	TargetName string `json:"targetName,omitempty" bson:"targetName,omitempty"`
 	// Changes optionally captures the field-level diff for this event.
 	Changes []AuditFieldChange `json:"changes,omitempty" bson:"changes,omitempty"`
 	// Metadata holds contextual key/value pairs (ip, userAgent, requestId, ...).

--- a/pkg/models/auditevent_test.go
+++ b/pkg/models/auditevent_test.go
@@ -1,0 +1,44 @@
+package models
+
+import (
+	"testing"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+func TestAuditEventProjectIdBSON(t *testing.T) {
+	organisationId := primitive.NewObjectID()
+	projectId := primitive.NewObjectID()
+
+	encoded, err := bson.Marshal(AuditEvent{
+		OrganisationId: organisationId,
+		ProjectId:      &projectId,
+	})
+	if err != nil {
+		t.Fatalf("marshal project audit event: %v", err)
+	}
+
+	var document bson.M
+	if err := bson.Unmarshal(encoded, &document); err != nil {
+		t.Fatalf("unmarshal project audit event: %v", err)
+	}
+	if got := document["organisationId"]; got != organisationId {
+		t.Fatalf("organisationId = %#v, want %s", got, organisationId.Hex())
+	}
+	if got := document["projectId"]; got != projectId {
+		t.Fatalf("projectId = %#v, want %s", got, projectId.Hex())
+	}
+
+	encoded, err = bson.Marshal(AuditEvent{OrganisationId: organisationId})
+	if err != nil {
+		t.Fatalf("marshal organisation audit event: %v", err)
+	}
+	document = nil
+	if err := bson.Unmarshal(encoded, &document); err != nil {
+		t.Fatalf("unmarshal organisation audit event: %v", err)
+	}
+	if _, exists := document["projectId"]; exists {
+		t.Fatalf("organisation-only audit event persisted projectId: %#v", document["projectId"])
+	}
+}


### PR DESCRIPTION
## Summary

- add optional ObjectID `projectId` to canonical audit events
- align the shared audit event with active writer fields: actor type, operation, category, outcome, and target name
- preserve organisation-owned events with no project context
- add BSON contract tests

## Contract

`organisationId` is the audit stream owner. `projectId` is optional target/action context, not a replacement tenant boundary. Organisation/membership/billing actions omit it; project-resource actions copy authoritative target/source ownership.

## Validation

Full tests, vet, module verification, and focused BSON tests pass.

## Release order

Publish the next models tag after merge, then Hub API and Notification can replace their local DTOs with the shared type.