### PR TITLE
feat: add stable owner identity resolver

### DIFF
--- a/pkg/models/user.go
+++ b/pkg/models/user.go
@@ -20,6 +20,17 @@ func GetUserIdFromAccountOrMaster(user User) string {
 	return GetOrganisationObjectId(user).Hex()
 }
 
+// StableOwnerObjectId returns the user's durable legacy owner identity without
+// consulting mutable organisation selection. Sub-users resolve through their
+// stored master account; owners and malformed legacy relationships use their
+// own ID.
+func StableOwnerObjectId(user User) primitive.ObjectID {
+	if masterId, err := primitive.ObjectIDFromHex(user.MasterAccount); err == nil && !masterId.IsZero() {
+		return masterId
+	}
+	return user.Id
+}
+
 // GetOrganisationId returns the hex-string organisation id for this user. It is
 // retained for the legacy ownership fields that are still stored as strings
 // (e.g. Device/AccessToken/CaseMedia organisationId). New org/RBAC code that

--- a/pkg/models/user_test.go
+++ b/pkg/models/user_test.go
@@ -79,3 +79,27 @@ func TestGetOrganisationObjectIdHandlesUnhydratedMaster(t *testing.T) {
 		t.Fatalf("organisation id = %s, want %s", got.Hex(), userId.Hex())
 	}
 }
+
+func TestStableOwnerObjectIdIgnoresActiveOrganisation(t *testing.T) {
+	userId := primitive.NewObjectID()
+	masterId := primitive.NewObjectID()
+	activeOrganisationId := primitive.NewObjectID()
+
+	if got := StableOwnerObjectId(User{
+		Id:             userId,
+		MasterAccount:  masterId.Hex(),
+		OrganisationId: activeOrganisationId,
+	}); got != masterId {
+		t.Fatalf("stable owner = %s, want master %s", got.Hex(), masterId.Hex())
+	}
+	if got := StableOwnerObjectId(User{Id: userId, OrganisationId: activeOrganisationId}); got != userId {
+		t.Fatalf("stable owner = %s, want own ID %s", got.Hex(), userId.Hex())
+	}
+}
+
+func TestStableOwnerObjectIdRejectsMalformedMaster(t *testing.T) {
+	userId := primitive.NewObjectID()
+	if got := StableOwnerObjectId(User{Id: userId, MasterAccount: "invalid"}); got != userId {
+		t.Fatalf("stable owner = %s, want own ID %s", got.Hex(), userId.Hex())
+	}
+}


### PR DESCRIPTION
## Description

This change introduces `StableOwnerObjectId`, a dedicated resolver for deriving a user's durable legacy owner identity without relying on the currently selected organisation.

The existing ownership resolution logic depends on mutable organisation state, which can lead to inconsistent identity mapping when users switch organisations or when legacy ownership fields are evaluated outside the current org context. By resolving sub-users through their persisted `MasterAccount` relationship and falling back safely to the user's own ID, this implementation provides a stable and predictable ownership identifier.

This improves the project by:
- Preserving consistent legacy ownership behaviour regardless of active organisation selection.
- Reducing the risk of incorrect ownership attribution caused by mutable runtime state.
- Handling malformed legacy relationships safely by falling back to the user's own ID instead of failing unpredictably.
- Establishing clearer separation between organisation context and durable ownership identity.

The accompanying tests validate the expected behaviour for sub-users, primary owners, organisation switching scenarios, and malformed master account values.